### PR TITLE
Define a new rpc signal to trigger a refresh of the host model in the UI

### DIFF
--- a/interfaces/ctxusb_daemon.xml
+++ b/interfaces/ctxusb_daemon.xml
@@ -129,6 +129,9 @@
 			</arg>
 		</signal>
 		
+		<signal name="optical_device_detected">
+			<tp:docstring>Signal that we have a new optical device and refresh the host model.</tp:docstring>
+		</signal>
 		<signal name="devices_changed">
 			<tp:docstring>Device list previously given out may be out of date, re-enumerate.</tp:docstring>
 		</signal>


### PR DESCRIPTION
OXT-222

Add support for a new signal to be called from usbdaemon.  This signal
is recognized in the ui and is used to trigger a host refresh for the
purpose of listing new cd devices.

Signed-off by: Chris Rogers rogersc@ainfosec.com