### PR TITLE
[xcpmd] Add call & signal for UIVM battery applet

### DIFF
--- a/interfaces/xcpmd.xml
+++ b/interfaces/xcpmd.xml
@@ -3,6 +3,15 @@
   
   <interface name="com.citrix.xenclient.xcpmd">
 
+    <method name="batteries_present">
+      <tp:docstring>Returns a list of indices of the batteries currently present.
+      </tp:docstring>
+      <arg type="ai" name="batteries" direction="out">
+        <tp:docstring>Indices of the batteries currently present.
+        </tp:docstring>
+      </arg>
+    </method>
+
     <method name="battery_time_to_empty">
       <tp:docstring>Returns when bat_n will be empty, in seconds, or 0
       if the battery is not currently discharging</tp:docstring>

--- a/interfaces/xcpmd.xml
+++ b/interfaces/xcpmd.xml
@@ -100,6 +100,10 @@
       </arg>
     </method>
 
+    <signal name="num_batteries_changed">
+      <tp:docstring>Signals change in number of batteries present.</tp:docstring>
+    </signal>
+
     <signal name="ac_adapter_state_changed">
       <tp:docstring>Signals change in platform AC adapter status.</tp:docstring>
     </signal>


### PR DESCRIPTION
To support an arbitrarily large number of batteries that may skip index numbers, the UIVM needs to know what batteries are currently present and it should be notified when any battery is added or removed.

Depends on [xctools PR13](https://github.com/OpenXT/xctools/pull/13).