### PR TITLE
Xenmgr idl changes

### DIFF
--- a/interfaces/xenmgr.xml
+++ b/interfaces/xenmgr.xml
@@ -131,6 +131,12 @@
       <arg name="uuid" type="s"/>
       <arg name="obj_path" type="o"/>
     </signal>
+	
+	<signal name="notify">
+	  <tp:docstring>Send out generic notification, details inside string arg.</tp:docstring>
+      <arg name="uuid" type="s"/>
+      <arg name="messsage" type="s"/>
+	</signal>
 
     <signal name="vm_state_changed">
       <tp:docstring>Notify that VM state has changed.</tp:docstring>

--- a/interfaces/xenmgr.xml
+++ b/interfaces/xenmgr.xml
@@ -134,8 +134,8 @@
 	
 	<signal name="notify">
 	  <tp:docstring>Send out generic notification, details inside string arg.</tp:docstring>
-      <arg name="uuid" type="s"/>
-      <arg name="messsage" type="s"/>
+	  <arg name="uuid" type="s"/>
+	  <arg name="messsage" type="s"/>
 	</signal>
 
     <signal name="vm_state_changed">

--- a/interfaces/xenmgr_vm.xml
+++ b/interfaces/xenmgr_vm.xml
@@ -43,6 +43,7 @@
     <property name="notify" type="s" access="readwrite"/>
     <property name="hvm" type="b" access="readwrite"/>
     <property name="pae" type="b" access="readwrite"/>
+	<property name="acpi" type="b" access="readwrite"/>
     <property name="apic" type="b" access="readwrite"/>
     <property name="viridian" type="b" access="readwrite"/>
     <property name="hap" type="b" access="readwrite"/>
@@ -71,10 +72,10 @@
       </tp:docstring>
     </property>
     <property name="initrd" type="s" access="readwrite"/>
-    <property name="acpi-pt" type="b" access="readwrite">
+    <property name="acpi-path" type="s" access="readwrite">
       <tp:docstring>Enable OEM windows install by exposing the ACPI SLIC table.</tp:docstring>
     </property>
-    <property name="smbios-pt" type="b" access="readwrite"/>
+    <property name="smbios" type="s" access="readwrite"/>
     <property name="vcpus" type="i" access="readwrite"/>
     <property name="cores-per-socket" type="i" access="readwrite"/>
     <property name="videoram" type="i" access="readwrite"/>
@@ -198,7 +199,7 @@
     <property name="preserve-on-reboot" type="b" access="readwrite"><tp:docstring>After reboot, keep the vm in rebooted state instead of automatically restarting it</tp:docstring></property>
     <property name="boot-sentinel" type="s" access="readwrite"><tp:docstring>Name of xenstore node to wait on before completing vm startup from toolstack PoV. Useful if VM exports services which need to be immediately usable by other vms</tp:docstring></property>
     <property name="hpet" type="b" access="readwrite"><tp:docstring>HPET support</tp:docstring></property>
-    <property name="timer-mode" type="i" access="readwrite"><tp:docstring>Domain timer mode</tp:docstring></property>
+    <property name="timer-mode" type="s" access="readwrite"><tp:docstring>Domain timer mode</tp:docstring></property>
     <property name="nestedhvm" type="b" access="readwrite"><tp:docstring>Enable nested virtualization</tp:docstring></property>
     <property name="serial" type="s" access="readwrite"><tp:docstring>Serial port specification</tp:docstring></property>
 
@@ -376,6 +377,7 @@
     <property name="notify" type="s" access="readwrite"/>
     <property name="hvm" type="b" access="readwrite"/>
     <property name="pae" type="b" access="readwrite"/>
+	<property name="acpi" type="b" access="readwrite"/>
     <property name="apic" type="b" access="readwrite"/>
     <property name="viridian" type="b" access="readwrite"/>
     <property name="cpuid" type="s" access="readwrite"><tp:docstring>Used to set/unset certain bits in response to CPUID instruction.</tp:docstring></property>
@@ -404,10 +406,10 @@
       </tp:docstring>
     </property>
     <property name="initrd" type="s" access="readwrite"/>
-    <property name="acpi-pt" type="b" access="readwrite">
+    <property name="acpi-path" type="s" access="readwrite">
       <tp:docstring>Enable OEM windows installation by exposing the ACPI SLIC table.</tp:docstring>
     </property>
-    <property name="smbios-pt" type="b" access="readwrite"/>
+    <property name="smbios" type="s" access="readwrite"/>
     <property name="vcpus" type="i" access="readwrite"/>
     <property name="cores-per-socket" type="i" access="readwrite"/>
     <property name="videoram" type="i" access="readwrite"/>
@@ -534,7 +536,7 @@
     <property name="preserve-on-reboot" type="b" access="readwrite"><tp:docstring>After reboot, keep the vm in rebooted state instead of automatically restarting it</tp:docstring></property>
     <property name="boot-sentinel" type="s" access="readwrite"><tp:docstring>Name of xenstore node to wait on before completing vm startup from toolstack PoV. Useful if VM exports services which need to be immediately usable by other vms</tp:docstring></property>
     <property name="hpet" type="b" access="readwrite"><tp:docstring>HPET support</tp:docstring></property>
-    <property name="timer-mode" type="i" access="readwrite"><tp:docstring>Domain timer mode</tp:docstring></property>
+    <property name="timer-mode" type="s" access="readwrite"><tp:docstring>Domain timer mode</tp:docstring></property>
     <property name="nestedhvm" type="b" access="readwrite"><tp:docstring>Enable nested virtualization</tp:docstring></property>
     <property name="serial" type="s" access="readwrite"><tp:docstring>Serial port specification</tp:docstring></property>
   </interface>


### PR DESCRIPTION
* Add generic notify signal for xenmgr
* change name/type of acpi-pt and smbios-pt properties for vms to
  support changes in xenmgr.

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>