### PR TITLE
OXT-1383: idl: Add VirtType to support PVH

### DIFF
--- a/interfaces/xenmgr_vm.xml
+++ b/interfaces/xenmgr_vm.xml
@@ -1,6 +1,12 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node name="/vm/uuid" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
 
+  <tp:enum name="VIRT_TYPE" type="s">
+    <tp:docstring>Xen virtualization type.</tp:docstring>
+    <tp:enumvalue suffix="PV" value="pv"/>
+    <tp:enumvalue suffix="PVH" value="pvh"/>
+    <tp:enumvalue suffix="HVM" value="hvm"/>
+  </tp:enum>
   <interface name="com.citrix.xenclient.xenmgr.vm">
     <tp:docstring>VM interface. Property access goes through policy checks.</tp:docstring>
     <property name="state" type="s" access="read"/>
@@ -41,7 +47,7 @@
     <property name="hidden-in-ui" type="b" access="readwrite"/>
 
     <property name="notify" type="s" access="readwrite"/>
-    <property name="hvm" type="b" access="readwrite"/>
+    <property name="virt-type" type="s" access="readwrite"/><tp:docstring>One of pv, pvh, or hvm.</tp:docstring>
     <property name="pae" type="b" access="readwrite"/>
 	<property name="acpi" type="b" access="readwrite"/>
     <property name="apic" type="b" access="readwrite"/>
@@ -374,7 +380,7 @@
     <property name="hidden-in-ui" type="b" access="readwrite"/>
 
     <property name="notify" type="s" access="readwrite"/>
-    <property name="hvm" type="b" access="readwrite"/>
+    <property name="virt-type" type="s" access="readwrite"/><tp:docstring>One of pv, pvh, or hvm.</tp:docstring>
     <property name="pae" type="b" access="readwrite"/>
 	<property name="acpi" type="b" access="readwrite"/>
     <property name="apic" type="b" access="readwrite"/>


### PR DESCRIPTION
HVM as a boolean cannot express PVH.  Switch to the new VIRT_TYPE enum
to support PVH along with PV and HVM.

OXT-1383

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>