### PR TITLE
x86_64: Cleanup xenmgr_vm interface

### DIFF
--- a/interfaces/xenmgr_vm.xml
+++ b/interfaces/xenmgr_vm.xml
@@ -358,6 +358,9 @@
     <property name="start-from-suspend-image" type="s" access="readwrite"><tp:docstring>Start the VM from the suspend image file, if it exists.</tp:docstring></property>
     <property name="time-offset" type="i" access="readwrite"/>
     <property name="crypto-user" type="s" access="readwrite"/>
+    <property name="crypto-key-dirs" type="s" access="readwrite">
+      <tp:docstring>Comma-separated list of disk encryption keys directories.</tp:docstring>
+    </property>
     <property name="auto-s3-wake" type="b" access="readwrite"/>
     <property name="os" type="s" access="readwrite"/>
 
@@ -421,14 +424,6 @@
     <property name="passthrough-mmio" type="s" access="readwrite"/>
     <property name="passthrough-io" type="s" access="readwrite"/>
     <property name="flask-label" type="s" access="readwrite"/>
-    <property name="qemu-dm-path" type="s" access="readwrite"/>
-    <property name="qemu-dm-timeout" type="i" access="readwrite">
-      <tp:docstring>Timeout (in seconds) to wait for qemu response during its startup.</tp:docstring>
-    </property>
-
-    <property name="oem-acpi-features" type="b" access="readwrite">
-      <tp:docstring>Enables access to additional OEM acpi features.</tp:docstring>
-    </property>
 
     <property name="start-on-boot-priority" type="i" access="readwrite">
       <tp:docstring>Control priority of start-on-boot VMs, higher priority means earlier start. For new VMs this defaults to 0.</tp:docstring>
@@ -466,35 +461,10 @@
       <tp:docstring>Extra ioemu arguments separated by semicolon.</tp:docstring>
     </property>
 
-    <property name="crypto-key-dirs" type="s" access="readwrite">
-      <tp:docstring>Comma-separated list of disk encryption keys directories.</tp:docstring>
-    </property>
-
-    <property name="dependencies" type="ao" access="read">
-      <tp:docstring>VMs that are required to be running before starting this one.</tp:docstring>
-    </property>
-
-    <property name="track-dependencies" type="b" access="readwrite">
-      <tp:docstring>If true, automatically start required VMs.</tp:docstring>
-    </property>
-
-    <property name="seamless-mouse-left" type="i" access="read">
-      <tp:docstring>Where to move mouse when it goes over left edge.</tp:docstring>
-    </property>
-
-    <property name="seamless-mouse-right" type="i" access="read">
-      <tp:docstring>Where to move mouse when it goes over right edge.</tp:docstring>
-    </property>
-
-    <property name="control-platform-power-state" type="b" access="readwrite">
-      <tp:docstring>If set, whole platform will go into S3/S4/S5 when this VM goes into S3/S4/S5.</tp:docstring>
-    </property>
-
     <property name="stubdom" type="b" access="readwrite"> <tp:docstring>Use stub domain to hide the device emulator.</tp:docstring> </property>
     <property name="stubdom-memory" type="i" access="readwrite"> <tp:docstring>Memory given to the stubdomain, in megabytes.</tp:docstring> </property>
     <property name="stubdom-cmdline" type="s" access="readwrite"> <tp:docstring>Cmdline to be appended to the stubdomain's default cmdline.</tp:docstring> </property>
     <property name="usb-enabled" type="b" access="readwrite"><tp:docstring>Enables PV USB support.</tp:docstring></property>
-    <property name="usb-auto-passthrough" type="b" access="readwrite"><tp:docstring>Enables automatic passthrough of new USB devices to VM currently in focus upon plugging in.</tp:docstring></property>
     <property name="usb-control" type="b" access="readwrite"><tp:docstring>Enables VM to talk to USB daemon</tp:docstring></property>
     <property name="usb-grab-devices" type="b" access="readwrite"><tp:docstring>Automatically assign all available USB devices upon this VM start.</tp:docstring></property>
     <property name="greedy-pciback-bind" type="b" access="readwrite"><tp:docstring>Bind passthrough pci devices to pciback early, to prevent their use by other VMs.</tp:docstring></property>


### PR DESCRIPTION
The VM interface actually duplicates almost every property and method.
  com.citrix.xenclient.xenmgr.vm   and
  com.citrix.xenclient.xenmgr.vm.unrestricted

  The properties being removed have are from the unrestricted interface
  and have no backend implementation in Xenmgr. Therefore, extra code
  is being autogenerated that doesn't need to be. Also we shouldn't
  advertise functions that don't actually exist.

  One property is higher up in the file to match where it's found
  in Xenmgr's VmObject.hs file. This is an organizational change.

  Overall, these changes are cleanup only and are not x64 dependent.

Signed-off-by: Chris <rogersc@ainfosec.com>