### PR TITLE
Add init-flask-label and stubdom-flask-label

### DIFF
--- a/interfaces/xenmgr_vm.xml
+++ b/interfaces/xenmgr_vm.xml
@@ -87,6 +87,8 @@
     <property name="passthrough-mmio" type="s" access="readwrite"/>
     <property name="passthrough-io" type="s" access="readwrite"/>
     <property name="flask-label" type="s" access="readwrite"/>
+    <property name="init-flask-label" type="s" access="readwrite"/>
+    <property name="stubdom-flask-label" type="s" access="readwrite"/>
     <property name="qemu-dm-path" type="s" access="readwrite"/>
     <property name="qemu-dm-timeout" type="i" access="readwrite">
       <tp:docstring>Timeout (in seconds) to wait for qemu response during qemu startup.</tp:docstring>
@@ -422,6 +424,8 @@
     <property name="passthrough-mmio" type="s" access="readwrite"/>
     <property name="passthrough-io" type="s" access="readwrite"/>
     <property name="flask-label" type="s" access="readwrite"/>
+    <property name="init-flask-label" type="s" access="readwrite"/>
+    <property name="stubdom-flask-label" type="s" access="readwrite"/>
     <property name="qemu-dm-path" type="s" access="readwrite"/>
     <property name="qemu-dm-timeout" type="i" access="readwrite">
       <tp:docstring>Timeout (in seconds) to wait for qemu response during its startup.</tp:docstring>


### PR DESCRIPTION
These expose the guest's configuration for the build (init) and stubdom
flask labels.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

Needed by https://github.com/OpenXT/manager/pull/151