### PR TITLE
S9: [argo] Replace v4v with argo

### DIFF
--- a/interfaces/xenmgr.xml
+++ b/interfaces/xenmgr.xml
@@ -197,7 +197,7 @@
     <property name="autostart" type="b" access="readwrite"/>
     <property name="pvm-autostart-delay" type="i" access="readwrite"/>
     <property name="svm-autostart-delay" type="i" access="readwrite"/>
-    <property name="v4v-hosts-file" type="b" access="readwrite"/>
+    <property name="argo-hosts-file" type="b" access="readwrite"/>
     <property name="use-networking-domain" type="b" access="read"/>
     <property name="bypass-sha1sum-checks" type="b" access="read"/>
     <property name="xc-diag-timeout" type="i" access="readwrite"/>
@@ -213,8 +213,8 @@
     <property name="connect-remote-desktop-allowed" type="b" access="readwrite"><tp:docstring>Allow using remote desktop (via icavm).</tp:docstring></property>
 
     <property name="measure-fail-action" type="s" access="readwrite"> <tp:docstring>Action to perform when computing service VM checksum fails: sleep,hibernate,shutdown,reboot,nothing.</tp:docstring></property>
-    <property name="v4v-firewall" type="b" access="readwrite">
-      <tp:docstring>If true, v4v firewall is enabled, rejecting all incoming traffic by default.</tp:docstring>
+    <property name="argo-firewall" type="b" access="readwrite">
+      <tp:docstring>If true, argo firewall is enabled, rejecting all incoming traffic by default.</tp:docstring>
     </property>
 
     <property name="secondary-gpu-pt" type="b" access="read">
@@ -229,7 +229,7 @@
       <tp:docstring>Enable external SSH access to dom0.</tp:docstring>
     </property>
 
-    <property name="enable-v4v-ssh" type="b" access="readwrite">
+    <property name="enable-argo-ssh" type="b" access="readwrite">
       <tp:docstring>Enable internal SSH access to dom0.</tp:docstring>
     </property>
 

--- a/interfaces/xenmgr_vm.xml
+++ b/interfaces/xenmgr_vm.xml
@@ -191,7 +191,7 @@
     <property name="vsnd" type="b" access="readwrite"><tp:docstring>Use PV audio device.</tp:docstring></property>
     <property name="vkbd" type="b" access="readwrite"><tp:docstring>Use PV keyboard and mouse.</tp:docstring></property>
     <property name="vfb" type="b" access="readwrite"><tp:docstring>Use PV framebuffer.</tp:docstring></property>
-    <property name="v4v" type="b" access="readwrite"><tp:docstring>Use V4V.</tp:docstring></property>
+    <property name="argo" type="b" access="readwrite"><tp:docstring>Use Argo.</tp:docstring></property>
     <property name="private-space" type="i" access="read"><tp:docstring>Private space used (in MiB).</tp:docstring></property>
     <property name="realm" type="s" access="readwrite"><tp:docstring>Realm ID.</tp:docstring></property>
     <property name="sync-uuid" type="s" access="readwrite"><tp:docstring>VM UUID in synchroniser space.</tp:docstring></property>
@@ -323,9 +323,9 @@
       <arg name="path" type="o" direction="out"/>
     </method>
 
-    <method name="list_v4v_firewall_rules"> <arg name="rules" type="as" direction="out"/> </method>
-    <method name="add_v4v_firewall_rule"> <arg name="rule" type="s" direction="in"/> </method>
-    <method name="delete_v4v_firewall_rule"> <arg name="rule" type="s" direction="in"/> </method>
+    <method name="list_argo_firewall_rules"> <arg name="rules" type="as" direction="out"/> </method>
+    <method name="add_argo_firewall_rule"> <arg name="rule" type="s" direction="in"/> </method>
+    <method name="delete_argo_firewall_rule"> <arg name="rule" type="s" direction="in"/> </method>
 
     <method name="add_net_firewall_rule">
       <arg name="id" type="i" direction="in"/>
@@ -529,7 +529,7 @@
     <property name="vsnd" type="b" access="readwrite"><tp:docstring>Use PV audio device.</tp:docstring></property>
     <property name="vkbd" type="b" access="readwrite"><tp:docstring>Use PV keyboard and mouse.</tp:docstring></property>
     <property name="vfb" type="b" access="readwrite"><tp:docstring>Use PV framebuffer.</tp:docstring></property>
-    <property name="v4v" type="b" access="readwrite"><tp:docstring>Use V4V.</tp:docstring></property>
+    <property name="argo" type="b" access="readwrite"><tp:docstring>Use Argo.</tp:docstring></property>
     <property name="private-space" type="i" access="read"><tp:docstring>Private space used (in MiB).</tp:docstring></property>
     <property name="realm" type="s" access="readwrite"><tp:docstring>Realm ID.</tp:docstring></property>
     <property name="sync-uuid" type="s" access="readwrite"><tp:docstring>VM UUID in Synchroniser space.</tp:docstring></property>


### PR DESCRIPTION
Basic find and replace. All references to v4v in
method names, properties, and doc strings were
changed to their argo equivalents.

OXT-1464

Signed-off-by: Nicholas Tsirakis <tsirakisn@ainfosec.com>