### PR TITLE
Organize idl

### DIFF
--- a/interfaces/ctxusb_daemon.xml
+++ b/interfaces/ctxusb_daemon.xml
@@ -1,50 +1,24 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
-	<interface name="com.citrix.xenclient.usbdaemon">
-		<tp:docstring>Interface to the USB policy daemon.</tp:docstring>
-		<method name="get_policy_domuuid">
-			<tp:docstring>Query the USB device policy for a specified VM.</tp:docstring>
-			<arg name="uuid" type="s" direction="in">
-				<tp:docstring>UUID of VM to query policy for.</tp:docstring>
-			</arg>
-			<arg name="value" type="s" direction="out">
-				<tp:docstring>Policy for specified VM, as XML.</tp:docstring>
-			</arg>
-		</method>
-		<method name="set_policy_domuuid">
-			<tp:docstring>Set the USB device policy for a specified VM.</tp:docstring>
-			<arg name="uuid" type="s" direction="in">
-				<tp:docstring>UUID of VM to query policy for.</tp:docstring>
-			</arg>
-			<arg name="policy" type="s" direction="in">
-				<tp:docstring>Policy for specified VM, as XML.</tp:docstring>
-			</arg>
-		</method>
-
-		<method name="new_vm">
-			<tp:docstring>Tell daemon a new VM has been started.</tp:docstring>
-			<arg name="dom_id" type="i" direction="in">
-				<tp:docstring>ID of newly started VM.</tp:docstring>
-			</arg>
-		</method>
-
-
-		<method name="vm_stopped">
-			<tp:docstring>Tell daemon a VM is stopping.</tp:docstring>
-			<arg name="dom_id" type="i" direction="in">
-				<tp:docstring>ID of stopping VM.</tp:docstring>
-			</arg>
-		</method>
-
-		<method name="list_devices">
-			<tp:docstring>Enumerate the USB devices plugged into the system.</tp:docstring>
-			<arg name="devices" type="ai" direction="out">
-				<tp:docstring>List of IDs of devices in the system.</tp:docstring>
-			</arg>
-		</method>
-
-		<method name="get_device_info">
-		<tp:docstring><p>Connection states are defined as follows:</p>
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
+  <interface name="com.citrix.xenclient.usbdaemon">
+    <tp:docstring>Interface to the USB policy daemon.</tp:docstring>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="assign_device">
+      <tp:docstring>Assign a device to a VM.</tp:docstring>
+      <arg name="dev_id" type="i" direction="in">
+        <tp:docstring>id of device to assign</tp:docstring>
+      </arg>
+      <arg name="vm_uuid" type="s" direction="in">
+        <tp:docstring>UUID of VM to assign device to.</tp:docstring>
+      </arg>
+    </method>
+    <method name="get_device_info">
+      <tp:docstring><p>Connection states are defined as follows:</p>
 		<ul>
 		<li>-1  Cannot find device</li>
 		<li>0  Device not in use by any VM</li>
@@ -61,97 +35,123 @@
 		<li>11 External CD drive in use by dom0, but "sticky" assigned to an off VM</li>
 		</ul>
 		</tp:docstring>
-			<arg name="dev_id" type="i" direction="in"><tp:docstring>ID of device to query.</tp:docstring>
-			</arg>
-			<arg name="vm_uuid" type="s" direction="in"> <tp:docstring>UUID of VM to get information relative to.</tp:docstring>
-			</arg>
-			<arg name="name" type="s" direction="out"><tp:docstring>Name of device.</tp:docstring>
-			</arg>
-			<arg name="state" type="i" direction="out"><tp:docstring>Connection state of device.</tp:docstring>
-			</arg>
-			<arg name="vm_assigned" type="s" direction="out"><tp:docstring>UUID of VM device is assigned to (if any).</tp:docstring>
-			</arg>
-			<arg name="detail" type="s" direction="out"><tp:docstring>Name detail, for mouse-over text.</tp:docstring>
-			</arg>
-		</method>
-
-		<method name="assign_device">
-			<tp:docstring>Assign a device to a VM.</tp:docstring>
-			<arg name="dev_id" type="i" direction="in">
-				<tp:docstring>id of device to assign</tp:docstring>
-			</arg>
-			<arg name="vm_uuid" type="s" direction="in">
-				<tp:docstring>UUID of VM to assign device to.</tp:docstring>
-			</arg>
-		</method>
-
-		<method name="unassign_device">
-			<tp:docstring>Unassign a device from a VM.</tp:docstring>
-			<arg name="dev_id" type="i" direction="in">
-				<tp:docstring>ID of device to unassign.</tp:docstring>
-			</arg>
-		</method>
-
-		<method name="set_sticky">
-			<tp:docstring>Set or clear the sticky assignment flag for a device.</tp:docstring>
-			<arg name="dev_id" type="i" direction="in">
-				<tp:docstring>ID of device to alter sticky flag for.</tp:docstring>
-			</arg>
-			<arg name="sticky" type="i" direction="in">
-				<tp:docstring>Set (1), or clear (0) sticky flag.</tp:docstring>
-			</arg>
-		</method>
-
-		<method name="name_device">
-			<tp:docstring>Set the user visible name for a device.</tp:docstring>
-			<arg name="dev_id" type="i" direction="in">
-				<tp:docstring>ID of device to set name for.</tp:docstring>
-			</arg>
-			<arg name="name" type="s" direction="in">
-				<tp:docstring>name to set for device</tp:docstring>
-			</arg>
-		</method>
-
-		<method name="state">
-			<tp:docstring>Dump daemon state, for debugging only.</tp:docstring>
-			<arg name="state" type="s" direction="out">
-				<tp:docstring>Daemon state in human readable form.</tp:docstring>
-			</arg>
-		</method>
-
-		<signal name="device_added">
-			<tp:docstring>A device was just added to the list</tp:docstring>
-			<arg name="dev_id" type="i">
-				<tp:docstring>ID of the new device</tp:docstring>
-			</arg>
-		</signal>
-
-		<method name="reload_policy">
-			<tp:docstring>Reload the policy rules from the database</tp:docstring>
-		</method>
-
-		<signal name="device_rejected">
-			<tp:docstring>A USB device has been rejected due to a policy.</tp:docstring>
-			<arg name="device_name" type="s">
-				<tp:docstring>User-friendly name of device rejected</tp:docstring>
-			</arg>
-			<arg name="reason" type="s">
-				<tp:docstring>Human-readable description of reason for rejection</tp:docstring>
-			</arg>
-		</signal>
-
-		<signal name="optical_device_detected">
-			<tp:docstring>Signal that we have a new optical device and refresh the host model.</tp:docstring>
-		</signal>
-		<signal name="devices_changed">
-			<tp:docstring>Device list previously given out may be out of date, re-enumerate.</tp:docstring>
-		</signal>
-
-		<signal name="device_info_changed">
-			<tp:docstring>Information previously given out regarding device may be out of date, re-query.</tp:docstring>
-			<arg name="dev_id" type="i">
-				<tp:docstring>ID of device needing re-query.</tp:docstring>
-			</arg>
-		</signal>
-	</interface>
+      <arg name="dev_id" type="i" direction="in">
+        <tp:docstring>ID of device to query.</tp:docstring>
+      </arg>
+      <arg name="vm_uuid" type="s" direction="in">
+        <tp:docstring>UUID of VM to get information relative to.</tp:docstring>
+      </arg>
+      <arg name="name" type="s" direction="out">
+        <tp:docstring>Name of device.</tp:docstring>
+      </arg>
+      <arg name="state" type="i" direction="out">
+        <tp:docstring>Connection state of device.</tp:docstring>
+      </arg>
+      <arg name="vm_assigned" type="s" direction="out">
+        <tp:docstring>UUID of VM device is assigned to (if any).</tp:docstring>
+      </arg>
+      <arg name="detail" type="s" direction="out">
+        <tp:docstring>Name detail, for mouse-over text.</tp:docstring>
+      </arg>
+    </method>
+    <method name="get_policy_domuuid">
+      <tp:docstring>Query the USB device policy for a specified VM.</tp:docstring>
+      <arg name="uuid" type="s" direction="in">
+        <tp:docstring>UUID of VM to query policy for.</tp:docstring>
+      </arg>
+      <arg name="value" type="s" direction="out">
+        <tp:docstring>Policy for specified VM, as XML.</tp:docstring>
+      </arg>
+    </method>
+    <method name="list_devices">
+      <tp:docstring>Enumerate the USB devices plugged into the system.</tp:docstring>
+      <arg name="devices" type="ai" direction="out">
+        <tp:docstring>List of IDs of devices in the system.</tp:docstring>
+      </arg>
+    </method>
+    <method name="name_device">
+      <tp:docstring>Set the user visible name for a device.</tp:docstring>
+      <arg name="dev_id" type="i" direction="in">
+        <tp:docstring>ID of device to set name for.</tp:docstring>
+      </arg>
+      <arg name="name" type="s" direction="in">
+        <tp:docstring>name to set for device</tp:docstring>
+      </arg>
+    </method>
+    <method name="new_vm">
+      <tp:docstring>Tell daemon a new VM has been started.</tp:docstring>
+      <arg name="dom_id" type="i" direction="in">
+        <tp:docstring>ID of newly started VM.</tp:docstring>
+      </arg>
+    </method>
+    <method name="reload_policy">
+      <tp:docstring>Reload the policy rules from the database</tp:docstring>
+    </method>
+    <method name="set_policy_domuuid">
+      <tp:docstring>Set the USB device policy for a specified VM.</tp:docstring>
+      <arg name="uuid" type="s" direction="in">
+        <tp:docstring>UUID of VM to query policy for.</tp:docstring>
+      </arg>
+      <arg name="policy" type="s" direction="in">
+        <tp:docstring>Policy for specified VM, as XML.</tp:docstring>
+      </arg>
+    </method>
+    <method name="set_sticky">
+      <tp:docstring>Set or clear the sticky assignment flag for a device.</tp:docstring>
+      <arg name="dev_id" type="i" direction="in">
+        <tp:docstring>ID of device to alter sticky flag for.</tp:docstring>
+      </arg>
+      <arg name="sticky" type="i" direction="in">
+        <tp:docstring>Set (1), or clear (0) sticky flag.</tp:docstring>
+      </arg>
+    </method>
+    <method name="state">
+      <tp:docstring>Dump daemon state, for debugging only.</tp:docstring>
+      <arg name="state" type="s" direction="out">
+        <tp:docstring>Daemon state in human readable form.</tp:docstring>
+      </arg>
+    </method>
+    <method name="unassign_device">
+      <tp:docstring>Unassign a device from a VM.</tp:docstring>
+      <arg name="dev_id" type="i" direction="in">
+        <tp:docstring>ID of device to unassign.</tp:docstring>
+      </arg>
+    </method>
+    <method name="vm_stopped">
+      <tp:docstring>Tell daemon a VM is stopping.</tp:docstring>
+      <arg name="dom_id" type="i" direction="in">
+        <tp:docstring>ID of stopping VM.</tp:docstring>
+      </arg>
+    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <signal name="device_added">
+      <tp:docstring>A device was just added to the list</tp:docstring>
+      <arg name="dev_id" type="i">
+        <tp:docstring>ID of the new device</tp:docstring>
+      </arg>
+    </signal>
+    <signal name="device_info_changed">
+      <tp:docstring>Information previously given out regarding device may be out of date, re-query.</tp:docstring>
+      <arg name="dev_id" type="i">
+        <tp:docstring>ID of device needing re-query.</tp:docstring>
+      </arg>
+    </signal>
+    <signal name="device_rejected">
+      <tp:docstring>A USB device has been rejected due to a policy.</tp:docstring>
+      <arg name="device_name" type="s">
+        <tp:docstring>User-friendly name of device rejected</tp:docstring>
+      </arg>
+      <arg name="reason" type="s">
+        <tp:docstring>Human-readable description of reason for rejection</tp:docstring>
+      </arg>
+    </signal>
+    <signal name="devices_changed">
+      <tp:docstring>Device list previously given out may be out of date, re-enumerate.</tp:docstring>
+    </signal>
+    <signal name="optical_device_detected">
+      <tp:docstring>Signal that we have a new optical device and refresh the host model.</tp:docstring>
+    </signal>
+  </interface>
 </node>

--- a/interfaces/db.xml
+++ b/interfaces/db.xml
@@ -1,21 +1,19 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node name="/">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.db">
-    <method name="read">
-      <arg name="path" type="s" direction="in"/>
-      <arg name="value" type="s" direction="out"/>
-    </method>
-    <method name="read_binary">
-      <arg name="path" type="s" direction="in"/>
-      <arg name="value" type="ay" direction="out"/>
-    </method>
-    <method name="write">
-      <arg name="path" type="s" direction="in"/>
-      <arg name="value" type="s" direction="in"/>
-    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="dump">
       <arg name="path" type="s" direction="in"/>
       <arg name="value" type="s" direction="out"/>
+    </method>
+    <method name="exists">
+      <arg name="path" type="s" direction="in"/>
+      <arg name="ex" type="b" direction="out"/>
     </method>
     <method name="inject">
       <arg name="path" type="s" direction="in"/>
@@ -25,12 +23,20 @@
       <arg name="path" type="s" direction="in"/>
       <arg name="value" type="as" direction="out"/>
     </method>
+    <method name="read">
+      <arg name="path" type="s" direction="in"/>
+      <arg name="value" type="s" direction="out"/>
+    </method>
+    <method name="read_binary">
+      <arg name="path" type="s" direction="in"/>
+      <arg name="value" type="ay" direction="out"/>
+    </method>
     <method name="rm">
       <arg name="path" type="s" direction="in"/>
     </method>
-    <method name="exists">
+    <method name="write">
       <arg name="path" type="s" direction="in"/>
-      <arg name="ex" type="b" direction="out"/>
+      <arg name="value" type="s" direction="in"/>
     </method>
   </interface>
 </node>

--- a/interfaces/guest.xml
+++ b/interfaces/guest.xml
@@ -1,27 +1,36 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.guest">
     <tp:docstring>Interface optionally implemented by the guest VM agent.</tp:docstring>
-	<method name="request_shutdown">
-	  <tp:docstring>Request a clean guest shutdown.</tp:docstring>
-	</method>
-	<method name="request_sleep">
-	  <tp:docstring>Request the s3 state.</tp:docstring>
-	</method>
-	<method name="request_hibernate">
-	  <tp:docstring>Request the s4 state.</tp:docstring>
-	</method>
-	<method name="request_reboot">
-	  <tp:docstring>Request a clean guest reboot.</tp:docstring>
-	</method>
-	<signal name="agent_started">
-	  <tp:docstring>Sent by the guest agent after it starts.</tp:docstring>
-	</signal>
-	<signal name="agent_uninstalled">
-	  <tp:docstring>Sent by the guest agent during the uninstall process.</tp:docstring>
-	</signal>
-	<signal name="xorg_running">
-	  <tp:docstring>Sent by the guest agent when the x server is detected.</tp:docstring>
-	</signal>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="request_hibernate">
+      <tp:docstring>Request the s4 state.</tp:docstring>
+    </method>
+    <method name="request_reboot">
+      <tp:docstring>Request a clean guest reboot.</tp:docstring>
+    </method>
+    <method name="request_shutdown">
+      <tp:docstring>Request a clean guest shutdown.</tp:docstring>
+    </method>
+    <method name="request_sleep">
+      <tp:docstring>Request the s3 state.</tp:docstring>
+    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <signal name="agent_started">
+      <tp:docstring>Sent by the guest agent after it starts.</tp:docstring>
+    </signal>
+    <signal name="agent_uninstalled">
+      <tp:docstring>Sent by the guest agent during the uninstall process.</tp:docstring>
+    </signal>
+    <signal name="xorg_running">
+      <tp:docstring>Sent by the guest agent when the x server is detected.</tp:docstring>
+    </signal>
   </interface>
 </node>

--- a/interfaces/input_daemon.xml
+++ b/interfaces/input_daemon.xml
@@ -1,283 +1,236 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.input">
-
-    <method name="set_slot">
-        <arg name="domid" type="i" direction="in"></arg>
-        <arg name="slot" type="i" direction="in"></arg>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="attach_vkbd">
+      <tp:docstring>Attach a VKBD (mouse and keyboard) to the given domain.</tp:docstring>
+      <arg type="i" name="domid" direction="in"/>
     </method>
-
-    <method name="auth_set_context">
-      <arg name="user" type="s" direction="in"></arg>
-      <arg name="title" type="s" direction="in"></arg>
-    </method>
-
-    <method name="auth_set_context_flags">
-      <arg name="user" type="s" direction="in"></arg>
-      <arg name="title" type="s" direction="in"></arg>
-      <arg name="flags" type="i" direction="in"></arg>
-    </method>
-
     <method name="auth_begin">
       <tp:docstring>Start authentication process.</tp:docstring>
-      <arg name="started" type="b" direction="out"></arg>
+      <arg name="started" type="b" direction="out"/>
     </method>
-
-    <method name="auth_remote_login">
-        <arg name="username" type="s" direction="in"></arg>
-        <arg name="password" type="s" direction="in"></arg>
-    </method>
-
-    <method name="auth_collect_password">
-    </method>
-
-    <method name="auth_title">
-      <arg name="title" type="s" direction="out"></arg>
-    </method>
-
-    <method name="auth_get_context">
-      <arg name="user" type="s" direction="out"></arg>
-      <arg name="title" type="s" direction="out"></arg>
-      <arg name="flags" type="i" direction="out"></arg>
-    </method>
-
-    <method name="auth_remote_status">
-      <arg name="auto_started" type="b" direction="in"></arg>
-      <arg name="status" type="i" direction="in"></arg>
-      <arg name="id" type="s" direction="in"></arg>
-      <arg name="username" type="s" direction="in"></arg>
-      <arg name="recovery_key_file" type="s" direction="in"></arg>
-      <arg name="ctx_flags" type="u" direction="in"></arg>
-    </method>
-
-    <method name="auth_get_status">
-      <arg name="clear" type="b" direction="in"></arg>
-      <arg name="status" type="s" direction="out"></arg>
-      <arg name="flags" type="i" direction="out"></arg>
-    </method>
-
-    <method name="auth_clear_status"></method>
-
+    <method name="auth_clear_status"/>
+    <method name="auth_collect_password"/>
     <method name="auth_create_hash">
-      <arg name="fname" type="s" direction="in"></arg>
-      <arg name="password" type="s" direction="in"></arg>
+      <arg name="fname" type="s" direction="in"/>
+      <arg name="password" type="s" direction="in"/>
     </method>
-
-    <method name="get_user_keydir">
-	  <tp:docstring>Get the user crypto keys directory, or empty string if not mounted.</tp:docstring>
-      <arg name="user" type="s" direction="in"></arg>
-      <arg name="dir" type="s" direction="out"></arg>
+    <method name="auth_get_context">
+      <arg name="user" type="s" direction="out"/>
+      <arg name="title" type="s" direction="out"/>
+      <arg name="flags" type="i" direction="out"/>
     </method>
-
-    <method name="get_remote_user_hash">
-      <tp:docstring>Get the remote user hash of the specified userid.</tp:docstring>
-      <arg name="userid" type="s" direction="in"></arg>
-      <arg name="hashed_userid" type="s" direction="out"></arg>
+    <method name="auth_get_status">
+      <arg name="clear" type="b" direction="in"/>
+      <arg name="status" type="s" direction="out"/>
+      <arg name="flags" type="i" direction="out"/>
     </method>
-
+    <method name="auth_remote_login">
+      <arg name="username" type="s" direction="in"/>
+      <arg name="password" type="s" direction="in"/>
+    </method>
+    <method name="auth_remote_status">
+      <arg name="auto_started" type="b" direction="in"/>
+      <arg name="status" type="i" direction="in"/>
+      <arg name="id" type="s" direction="in"/>
+      <arg name="username" type="s" direction="in"/>
+      <arg name="recovery_key_file" type="s" direction="in"/>
+      <arg name="ctx_flags" type="u" direction="in"/>
+    </method>
     <method name="auth_rm_platform_user">
       <tp:docstring>Used to recover access to platform when user has forgotten local password.</tp:docstring>
- 	  <arg name="success" type="b" direction="out"></arg>
-      <arg name="error_msg" type="s" direction="out"></arg>
+      <arg name="success" type="b" direction="out"/>
+      <arg name="error_msg" type="s" direction="out"/>
     </method>
-
-    <method name="get_focus_domid">
-      <tp:docstring>Get currently focussed domain ID.</tp:docstring>
-      <arg name="domid" type="i" direction="out"></arg>
+    <method name="auth_set_context">
+      <arg name="user" type="s" direction="in"/>
+      <arg name="title" type="s" direction="in"/>
     </method>
-
-    <method name="get_idle_time">
-      <tp:docstring>Get Idle Time of the Host.</tp:docstring>
-      <arg name="idle_time" type="i" direction="out"></arg>
+    <method name="auth_set_context_flags">
+      <arg name="user" type="s" direction="in"/>
+      <arg name="title" type="s" direction="in"/>
+      <arg name="flags" type="i" direction="in"/>
     </method>
-
-    <method name="get_last_input_time">
-      <tp:docstring>Returns the number of seconds since the most recent input activity or from start of input server.</tp:docstring>
-      <arg name="idle_time" type="i" direction="out"></arg>
+    <method name="auth_title">
+      <arg name="title" type="s" direction="out"/>
     </method>
-
-    <method name="switch_focus">
-      <tp:docstring>Move focus to different domain.</tp:docstring>
-      <arg name="domid" type="i" direction="in"></arg>
-      <arg name="force" type="b" direction="in"></arg>
-      <arg name="success" type="b" direction="out"></arg>
+    <method name="detach_vkbd">
+      <tp:docstring>Detach a VKBD (mouse and keyboard) from the given domain.</tp:docstring>
+      <arg type="i" name="domid" direction="in"/>
     </method>
-
-    <method name="get_platform_user">
-      <arg name="user" type="s" direction="out"></arg>
-      <arg name="flags" type="i" direction="out"></arg>
+    <method name="divert_keyboard_focus">
+      <tp:docstring>Diverts the keyboard focus to the provided VM, filtering provided key strokes, which continue to go to the original VM. 
+                    Key_filter is a null terminated array of key value sets, each of which is itself null terminated.</tp:docstring>
+      <arg type="s" name="uuid" direction="in"/>
     </method>
-
-    <method name="get_auth_on_boot">
-      <arg name="auth" type="b" direction="out"></arg>
-    </method>
-
-    <method name="set_auth_on_boot">
-      <arg name="auth" type="b" direction="in"></arg>
-    </method>
-
-    <method name="touchpad_get">
-      <arg name="prop" type="s" direction="in"></arg>
-      <arg name="value" type="s" direction="out"></arg>
-    </method>
-
-    <method name="touchpad_set">
-      <arg name="prop" type="s" direction="in"></arg>
-      <arg name="value" type="s" direction="in"></arg>
-    </method>
-
-    <method name="get_mouse_speed">
-      <arg name="mouse_speed" type="i" direction="out"></arg>
-    </method>
-
-    <method name="set_mouse_speed">
-      <arg name="mouse_speed" type="i" direction="in"></arg>
-    </method>
-
-    <method name="lock_timeout_set">
-      <arg name="value" type="i" direction="in"></arg>
-    </method>
-
-    <method name="lock_timeout_get">
-      <arg name="value" type="i" direction="out"></arg>
-    </method>
-
-    <method name="lock">
-      <arg name="can_switch_out" type="b" direction="in"></arg>
-    </method>
-
-    <method name="get_kb_layouts">
-      <arg name="layouts" type="as" direction="out"></arg>
-    </method>
-
-    <method name="get_current_kb_layout">
-      <arg name="layout" type="s" direction="out"></arg>
-    </method>
-
-    <method name="set_current_kb_layout">
-      <arg name="layout" type="s" direction="in"></arg>
-    </method>
-
-    <method name="update_seamless_mouse_settings">
-      <arg name="dom_uuid" type="s" direction="in"></arg>
-    </method>
-
-    <method name="get_lid_state">
-      <tp:docstring>Returns lid state.  A value of one indicates lid is open otherwise closed.</tp:docstring>
-      <arg type="u" name="lid_ret" direction="out" />
-    </method>
-
-
     <method name="divert_mouse_focus">
       <tp:docstring>Diverts the mouse focus to the provided VM, for mouse events occurring within the given source frame.  Events outside of this frame continue go to the calling VM.
        Mouse events are scaled to fit within the destination frame.  Any area outside of the destination frame will not be accessible with the mouse.
        Coordinates:  0 is always left/top most, 0x1FFF right/bottom most, regardless of screen resolution.</tp:docstring>
-      <arg type="s" name="uuid" direction="in" />
-
-      <arg type="u" name="sframe_x1" direction="in" />
-      <arg type="u" name="sframe_y1" direction="in" />
-      <arg type="u" name="sframe_x2" direction="in" />
-      <arg type="u" name="sframe_y2" direction="in" />
-
-      <arg type="u" name="dframe_x1" direction="in" />
-      <arg type="u" name="dframe_y1" direction="in" />
-      <arg type="u" name="dframe_x2" direction="in" /> 
-      <arg type="u" name="dframe_y2" direction="in" />
+      <arg type="s" name="uuid" direction="in"/>
+      <arg type="u" name="sframe_x1" direction="in"/>
+      <arg type="u" name="sframe_y1" direction="in"/>
+      <arg type="u" name="sframe_x2" direction="in"/>
+      <arg type="u" name="sframe_y2" direction="in"/>
+      <arg type="u" name="dframe_x1" direction="in"/>
+      <arg type="u" name="dframe_y1" direction="in"/>
+      <arg type="u" name="dframe_x2" direction="in"/>
+      <arg type="u" name="dframe_y2" direction="in"/>
     </method>
-
-    <method name="stop_mouse_divert">
-    <tp:docstring>This method stops a mouse focus divert, which was created using divert_mouse_focus.</tp:docstring>
+    <method name="focus_mode">
+      <tp:docstring>This bitfield allows the keyboard/mouse focus behaviour to be tweeked.  Bit 1 =KEYFOLLOWMOUSE, Bit 2 = CLICKHOLDFOCUS, Bit 3 = CLONEEVENTS.
+                   The default mode is 0.
+    </tp:docstring>
+      <arg type="i" name="mode" direction="in"/>
     </method>
-
+    <method name="get_auth_on_boot">
+      <arg name="auth" type="b" direction="out"/>
+    </method>
+    <method name="get_current_kb_layout">
+      <arg name="layout" type="s" direction="out"/>
+    </method>
+    <method name="get_focus_domid">
+      <tp:docstring>Get currently focussed domain ID.</tp:docstring>
+      <arg name="domid" type="i" direction="out"/>
+    </method>
+    <method name="get_idle_time">
+      <tp:docstring>Get Idle Time of the Host.</tp:docstring>
+      <arg name="idle_time" type="i" direction="out"/>
+    </method>
+    <method name="get_kb_layouts">
+      <arg name="layouts" type="as" direction="out"/>
+    </method>
+    <method name="get_last_input_time">
+      <tp:docstring>Returns the number of seconds since the most recent input activity or from start of input server.</tp:docstring>
+      <arg name="idle_time" type="i" direction="out"/>
+    </method>
+    <method name="get_lid_state">
+      <tp:docstring>Returns lid state.  A value of one indicates lid is open otherwise closed.</tp:docstring>
+      <arg type="u" name="lid_ret" direction="out"/>
+    </method>
+    <method name="get_mouse_speed">
+      <arg name="mouse_speed" type="i" direction="out"/>
+    </method>
+    <method name="get_platform_user">
+      <arg name="user" type="s" direction="out"/>
+      <arg name="flags" type="i" direction="out"/>
+    </method>
+    <method name="get_remote_user_hash">
+      <tp:docstring>Get the remote user hash of the specified userid.</tp:docstring>
+      <arg name="userid" type="s" direction="in"/>
+      <arg name="hashed_userid" type="s" direction="out"/>
+    </method>
+    <method name="get_user_keydir">
+      <tp:docstring>Get the user crypto keys directory, or empty string if not mounted.</tp:docstring>
+      <arg name="user" type="s" direction="in"/>
+      <arg name="dir" type="s" direction="out"/>
+    </method>
+    <method name="lock">
+      <arg name="can_switch_out" type="b" direction="in"/>
+    </method>
+    <method name="lock_timeout_get">
+      <arg name="value" type="i" direction="out"/>
+    </method>
+    <method name="lock_timeout_set">
+      <arg name="value" type="i" direction="in"/>
+    </method>
+    <method name="set_auth_on_boot">
+      <arg name="auth" type="b" direction="in"/>
+    </method>
+    <method name="set_current_kb_layout">
+      <arg name="layout" type="s" direction="in"/>
+    </method>
     <method name="set_divert_keyboard_filter">
       <tp:docstring>This sets the keyboard filter, used with divert_keyboard_focus.  
                     Key_filter is an array of null terminated key value sets.
                     Each key value set consists of a list of key values for any modifer keys,
                      followed by a final activation key.</tp:docstring>
-      <arg type="au" name="key_filter" direction="in" />
+      <arg type="au" name="key_filter" direction="in"/>
     </method>
-
-
-    <method name="divert_keyboard_focus">
-      <tp:docstring>Diverts the keyboard focus to the provided VM, filtering provided key strokes, which continue to go to the original VM. 
-                    Key_filter is a null terminated array of key value sets, each of which is itself null terminated.</tp:docstring>
-      <arg type="s" name="uuid" direction="in" />
+    <method name="set_mouse_speed">
+      <arg name="mouse_speed" type="i" direction="in"/>
     </method>
-
+    <method name="set_slot">
+      <arg name="domid" type="i" direction="in"/>
+      <arg name="slot" type="i" direction="in"/>
+    </method>
     <method name="stop_keyboard_divert">
-    <tp:docstring>This method stops a keyboard focus divert, which was created using divert_keyboard_focus.</tp:docstring>
+      <tp:docstring>This method stops a keyboard focus divert, which was created using divert_keyboard_focus.</tp:docstring>
     </method>
-
+    <method name="stop_mouse_divert">
+      <tp:docstring>This method stops a mouse focus divert, which was created using divert_mouse_focus.</tp:docstring>
+    </method>
+    <method name="switch_focus">
+      <tp:docstring>Move focus to different domain.</tp:docstring>
+      <arg name="domid" type="i" direction="in"/>
+      <arg name="force" type="b" direction="in"/>
+      <arg name="success" type="b" direction="out"/>
+    </method>
     <method name="touch">
-    <tp:docstring>Introduce an input event, into the given VM, to defer it from sleeping. </tp:docstring>
-    <arg type="s" name="uuid" direction="in" />
+      <tp:docstring>Introduce an input event, into the given VM, to defer it from sleeping. </tp:docstring>
+      <arg type="s" name="uuid" direction="in"/>
     </method>
-   
-    <method name="focus_mode">
-    <tp:docstring>This bitfield allows the keyboard/mouse focus behaviour to be tweeked.  Bit 1 =KEYFOLLOWMOUSE, Bit 2 = CLICKHOLDFOCUS, Bit 3 = CLONEEVENTS.
-                   The default mode is 0.
-    </tp:docstring>
-    <arg type="i" name="mode" direction="in" />
+    <method name="touchpad_get">
+      <arg name="prop" type="s" direction="in"/>
+      <arg name="value" type="s" direction="out"/>
     </method>
-
-    <method name="attach_vkbd">
-    <tp:docstring>Attach a VKBD (mouse and keyboard) to the given domain.</tp:docstring>
-    <arg type="i" name="domid" direction="in" />
+    <method name="touchpad_set">
+      <arg name="prop" type="s" direction="in"/>
+      <arg name="value" type="s" direction="in"/>
     </method>
-
-    <method name="detach_vkbd">
-    <tp:docstring>Detach a VKBD (mouse and keyboard) from the given domain.</tp:docstring>
-    <arg type="i" name="domid" direction="in" />
+    <method name="update_seamless_mouse_settings">
+      <arg name="dom_uuid" type="s" direction="in"/>
     </method>
-
-    <property name="numlock-restore-on-switch" type="b" access="readwrite">
-    <tp:docstring>Restore NumLock status on switch to VM.</tp:docstring>
-    </property>
- 
-    <signal name="keyboard_focus_change">
-    <tp:docstring>This allows the monitoring of the keyboard focus, by signaling the UUID of the VM gaining focus.</tp:docstring>
-    <arg type="s" name="uuid" />
-    </signal>
-
-
-    <signal name="focus_auth_field">
-	  <tp:docstring>Sent to notify UI to focus the text field in secure mode.</tp:docstring>
-      <arg name="field_id" type="i"></arg>
-    </signal>
-
-    <signal name="sync_auth_username">
-      <tp:docstring>Sent to set the username in the UI in secure mode.</tp:docstring> 
-	  <arg name="username" type="s"></arg>
-    </signal>
-
-	<signal name="auth_status">
-      <tp:docstring>Sent to change the status in the UI in secure mode.</tp:docstring> 
-	  <arg name="status" type="s"></arg>
-	  <arg name="flags" type="i"></arg>
-    </signal>
-
-	<signal name="secure_mode">
-      <tp:docstring>Sent to the UI to enter secure mode.</tp:docstring> 
-	  <arg name="show" type="i"></arg>
-    </signal>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <signal name="auth_remote_start_login">
       <tp:docstring>Sent to the BED to kick off Synchronizer auth.</tp:docstring>
       <arg name="username" type="s"/>
       <arg name="ctx_flags" type="u"/>
     </signal>
-
     <signal name="auth_remote_start_recovery">
       <tp:docstring>Sent to the BED to get recovery key.</tp:docstring>
       <arg name="auto_started" type="b"/>
       <arg name="id" type="s"/>
       <arg name="username" type="s"/>
       <arg name="ctx_flags" type="u"/>
-  </signal>
-
-    <signal name="lid_state_changed">
-      <tp:docstring>Signals when a laptop lid is opened or closed.</tp:docstring>      
     </signal>
-
+    <signal name="auth_status">
+      <tp:docstring>Sent to change the status in the UI in secure mode.</tp:docstring>
+      <arg name="status" type="s"/>
+      <arg name="flags" type="i"/>
+    </signal>
+    <signal name="focus_auth_field">
+      <tp:docstring>Sent to notify UI to focus the text field in secure mode.</tp:docstring>
+      <arg name="field_id" type="i"/>
+    </signal>
+    <signal name="keyboard_focus_change">
+      <tp:docstring>This allows the monitoring of the keyboard focus, by signaling the UUID of the VM gaining focus.</tp:docstring>
+      <arg type="s" name="uuid"/>
+    </signal>
+    <signal name="lid_state_changed">
+      <tp:docstring>Signals when a laptop lid is opened or closed.</tp:docstring>
+    </signal>
+    <signal name="secure_mode">
+      <tp:docstring>Sent to the UI to enter secure mode.</tp:docstring>
+      <arg name="show" type="i"/>
+    </signal>
+    <signal name="sync_auth_username">
+      <tp:docstring>Sent to set the username in the UI in secure mode.</tp:docstring>
+      <arg name="username" type="s"/>
+    </signal>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Properties ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <property name="numlock-restore-on-switch" type="b" access="readwrite">
+      <tp:docstring>Restore NumLock status on switch to VM.</tp:docstring>
+    </property>
   </interface>
 </node>

--- a/interfaces/network.xml
+++ b/interfaces/network.xml
@@ -1,23 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
-  <tp:enum name="NETWORK_TYPE" type="s">
-    <tp:docstring>Network types.</tp:docstring>
-    <tp:enumvalue suffix="UNKNOWN" value="unknown"/>
-    <tp:enumvalue suffix="WIRED" value="wired"/>
-    <tp:enumvalue suffix="WIFI" value="wifi"/>
-    <tp:enumvalue suffix="MODEM" value="modem"/>
-    <tp:enumvalue suffix="INTERNAL" value="internal"/>
-    <tp:enumvalue suffix="ANY" value="any"/>
-    <tp:enumvalue suffix="VPN" value="vpn"/>
-  </tp:enum>
-
-  <tp:enum name="CONNECTION_TYPE" type="s">
-    <tp:docstring>Connection types.</tp:docstring>
-    <tp:enumvalue suffix="UNKNOWN" value="unknown"/>
-    <tp:enumvalue suffix="SHARED" value="shared"/>
-    <tp:enumvalue suffix="BRIDGED" value="bridged"/>
-  </tp:enum>
-
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
   <tp:enum name="ACTIVE_AP" type="s">
     <tp:docstring>Access point details used in extra_info method.</tp:docstring>
     <tp:enumvalue suffix="SSID" value="ssid"/>
@@ -29,53 +11,78 @@
     <tp:enumvalue suffix="WPAFLAGS" value="wpaflags"/>
     <tp:enumvalue suffix="RSNFLAGS" value="rsnflags"/>
   </tp:enum>
-
-
+  <tp:enum name="CONNECTION_TYPE" type="s">
+    <tp:docstring>Connection types.</tp:docstring>
+    <tp:enumvalue suffix="UNKNOWN" value="unknown"/>
+    <tp:enumvalue suffix="SHARED" value="shared"/>
+    <tp:enumvalue suffix="BRIDGED" value="bridged"/>
+  </tp:enum>
+  <tp:enum name="NETWORK_TYPE" type="s">
+    <tp:docstring>Network types.</tp:docstring>
+    <tp:enumvalue suffix="UNKNOWN" value="unknown"/>
+    <tp:enumvalue suffix="WIRED" value="wired"/>
+    <tp:enumvalue suffix="WIFI" value="wifi"/>
+    <tp:enumvalue suffix="MODEM" value="modem"/>
+    <tp:enumvalue suffix="INTERNAL" value="internal"/>
+    <tp:enumvalue suffix="ANY" value="any"/>
+    <tp:enumvalue suffix="VPN" value="vpn"/>
+  </tp:enum>
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.network">
-
-    <method name="is_configured">
-      <tp:docstring>Returns true if the network is setup.</tp:docstring>
-      <arg type="b" name="is_configured" direction="out" />
-    </method>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="configure">
       <tp:docstring>Configure a shared/bridged network.</tp:docstring>
-      <arg type="s" name="subnet" direction="in" />
+      <arg type="s" name="subnet" direction="in"/>
     </method>
-
+    <method name="is_configured">
+      <tp:docstring>Returns true if the network is setup.</tp:docstring>
+      <arg type="b" name="is_configured" direction="out"/>
+    </method>
     <method name="join">
       <tp:docstring>Join the VIF to this network.</tp:docstring>
-      <arg type="s" name="vif" direction="in" />
+      <arg type="s" name="vif" direction="in"/>
     </method>
-
     <method name="leave">
       <tp:docstring>Remove the VIF from this network.</tp:docstring>
-      <arg type="s" name="vif" direction="in" />
+      <arg type="s" name="vif" direction="in"/>
     </method>
-
   </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.network.config">
-    <property name="name" type="s" access="read"/>
-    <property name="bridge" type="s" access="read"/>
-    <property name="backend-uuid" type="s" access="read"/>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Properties ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <property name="active" type="b" access="read"/>
-    <property name="interface" type="s" access="read"/>
-    <property name="mac-address" type="s" access="readwrite"/>
-    <property name="driver" type="s" access="read"/>
-    <property name="type" type="s" access="read"/>
+    <property name="backend-uuid" type="s" access="read"/>
+    <property name="bridge" type="s" access="read"/>
     <property name="connection" type="s" access="read"/>
-    <property name="nm-state" type="u" access="read"/>
+    <property name="driver" type="s" access="read"/>
     <property name="extra-info" type="a{ss}" access="read"/>
+    <property name="interface" type="s" access="read"/>
     <property name="label" type="s" access="readwrite"/>
+    <property name="mac-address" type="s" access="readwrite"/>
+    <property name="name" type="s" access="read"/>
     <property name="nat-prefix" type="s" access="readwrite"/>
     <property name="nm-managed" type="b" access="read"/>
+    <property name="nm-state" type="u" access="read"/>
+    <property name="type" type="s" access="read"/>
   </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.network.notify">
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <signal name="state_changed">
-        <tp:docstring>Notifies daemon of network state changes.</tp:docstring>
-        <arg name="state" type="u"/>
+      <tp:docstring>Notifies daemon of network state changes.</tp:docstring>
+      <arg name="state" type="u"/>
     </signal>
   </interface>
 </node>

--- a/interfaces/network_daemon.xml
+++ b/interfaces/network_daemon.xml
@@ -1,103 +1,95 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
   <tp:enum name="NDVM_STATUS" type="u">
     <tp:docstring>NDVM Status.</tp:docstring>
     <tp:enumvalue suffix="STOPPED" value="0"/>
     <tp:enumvalue suffix="STARTED" value="1"/>
   </tp:enum>
- 
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.networkdaemon">
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="add_vif">
       <tp:docstring>Creates the corresponding VIF.</tp:docstring>
-      <arg type="u" name="domid" direction="in" />
-      <arg type="u" name="backend_domid" direction="in" />
-      <arg type="s" name="mac" direction="in" />
+      <arg type="u" name="domid" direction="in"/>
+      <arg type="u" name="backend_domid" direction="in"/>
+      <arg type="s" name="mac" direction="in"/>
     </method>
-
+    <method name="create_network">
+      <tp:docstring>Creates network using configuration.</tp:docstring>
+      <arg type="s" name="network_type" direction="in"/>
+      <arg type="i" name="id" direction="in"/>
+      <arg type="s" name="config" direction="in"/>
+      <arg type="s" name="network" direction="out"/>
+    </method>
+    <method name="get_network_backend">
+      <tp:docstring>Returns network backend for a network.</tp:docstring>
+      <arg type="s" name="network" direction="in"/>
+      <arg type="s" name="uuid" direction="out"/>
+    </method>
+    <method name="is_initialized">
+      <tp:docstring>Returns true if all the slave network configuration is complete.</tp:docstring>
+      <arg type="b" name="is_initialized" direction="out"/>
+    </method>
+    <method name="is_networking_active">
+      <tp:docstring>Returns true if any of the slave networks are up and running.</tp:docstring>
+      <arg type="b" name="is_nw_active" direction="out"/>
+    </method>
+    <method name="list">
+      <tp:docstring>Lists networks.</tp:docstring>
+      <arg type="aa{ss}" name="networks" direction="out"/>
+    </method>
+    <method name="list_backends">
+      <tp:docstring>Lists network backend domains.</tp:docstring>
+      <arg type="as" name="backends" direction="out"/>
+    </method>
     <method name="move_to_network">
       <tp:docstring>Move VIF to network.</tp:docstring>
-      <arg type="s" name="vif" direction="in" />
-      <arg type="s" name="network" direction="in" />
+      <arg type="s" name="vif" direction="in"/>
+      <arg type="s" name="network" direction="in"/>
     </method>
-
     <method name="ndvm_status">
       <tp:docstring>To inform NDVM status.</tp:docstring>
-      <arg type="s" name="uuid" direction="in" />
-      <arg type="i" name="domid" direction="in" />
-      <arg type="u" name="status" direction="in" />
+      <arg type="s" name="uuid" direction="in"/>
+      <arg type="i" name="domid" direction="in"/>
+      <arg type="u" name="status" direction="in"/>
     </method>
-
     <method name="shutdown">
       <tp:docstring>Shuts down the network daemon.</tp:docstring>
     </method>
-
-     <method name="is_networking_active">
-      <tp:docstring>Returns true if any of the slave networks are up and running.</tp:docstring>
-      <arg type="b" name="is_nw_active" direction="out" />
-    </method>
-
-    <method name="list">
-      <tp:docstring>Lists networks.</tp:docstring>
-      <arg type="aa{ss}" name="networks" direction="out" />
-    </method>
-
-    <method name="list_backends">
-      <tp:docstring>Lists network backend domains.</tp:docstring>
-      <arg type="as" name="backends" direction="out" />
-    </method>
-
-    <method name="is_initialized">
-      <tp:docstring>Returns true if all the slave network configuration is complete.</tp:docstring>
-      <arg type="b" name="is_initialized" direction="out" />
-    </method>
-
     <method name="vif_connected">
       <tp:docstring>Returns true if the vif is connected in the appropriate network slave.</tp:docstring>
-      <arg type="s" name="vif" direction="in" />
-      <arg type="i" name="domid" direction="in" />
-      <arg type="b" name="connected" direction="out" />
+      <arg type="s" name="vif" direction="in"/>
+      <arg type="i" name="domid" direction="in"/>
+      <arg type="b" name="connected" direction="out"/>
     </method>
-
-    <method name="get_network_backend">
-      <tp:docstring>Returns network backend for a network.</tp:docstring>
-      <arg type="s" name="network" direction="in" />
-      <arg type="s" name="uuid" direction="out" />
-    </method>
-
-    <method name="create_network">
-      <tp:docstring>Creates network using configuration.</tp:docstring>
-      <arg type="s" name="network_type" direction="in" />
-      <arg type="i" name="id" direction="in" />
-      <arg type="s" name="config" direction="in" />
-      <arg type="s" name="network" direction="out" />
-    </method>
-
   </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.networkdaemon.notify">
-    <signal name="networkdaemon_up">
-        <tp:docstring>Notifies that the daemon is up.</tp:docstring>
-    </signal>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <signal name="network_added">
-        <tp:docstring>Notifies that a new network is added.</tp:docstring>
-        <arg name="network" type="s"/>
+      <tp:docstring>Notifies that a new network is added.</tp:docstring>
+      <arg name="network" type="s"/>
     </signal>
-
     <signal name="network_removed">
-        <tp:docstring>Notifies that a network is no longer available.</tp:docstring>
-        <arg name="network" type="s"/>
+      <tp:docstring>Notifies that a network is no longer available.</tp:docstring>
+      <arg name="network" type="s"/>
     </signal>
-
     <signal name="network_state_changed">
-        <tp:docstring>Notifies that a network is no longer available.</tp:docstring>
-        <arg name="network" type="s"/>
-        <arg name="nm_state" type="s"/>
-        <arg name="backend" type="s"/>
+      <tp:docstring>Notifies that a network is no longer available.</tp:docstring>
+      <arg name="network" type="s"/>
+      <arg name="nm_state" type="s"/>
+      <arg name="backend" type="s"/>
     </signal>
-
-
+    <signal name="networkdaemon_up">
+      <tp:docstring>Notifies that the daemon is up.</tp:docstring>
+    </signal>
   </interface>
-
 </node>

--- a/interfaces/network_domain.xml
+++ b/interfaces/network_domain.xml
@@ -1,34 +1,48 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.networkdomain">
-    <method name="list_networks">
-      <tp:docstring>Lists networks.</tp:docstring>
-      <arg type="as" name="networks" direction="out" />
-    </method>
-
-   <method name="popup_network_menu">
-      <tp:docstring>Signal the NM applet to popup the network menu.</tp:docstring>
-      <arg type="u" name="x_off" direction="in" />
-      <arg type="u" name="y_off" direction="in" />
-    </method>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="close_network_menu">
       <tp:docstring>Signal the NM applet to close the network menu.</tp:docstring>
     </method>
- </interface>
-
-  <interface name="com.citrix.xenclient.networkdomain.config">
-    <property name="uuid" type="s" access="read"/>
-    <property name="domid" type="u" access="read"/>
-    <property name="nm-state" type="u" access="read"/>
-    <property name="name" type="s" access="read"/>
-    <property name="is-networking-active" type="b" access="read"/>
+    <method name="list_networks">
+      <tp:docstring>Lists networks.</tp:docstring>
+      <arg type="as" name="networks" direction="out"/>
+    </method>
+    <method name="popup_network_menu">
+      <tp:docstring>Signal the NM applet to popup the network menu.</tp:docstring>
+      <arg type="u" name="x_off" direction="in"/>
+      <arg type="u" name="y_off" direction="in"/>
+    </method>
   </interface>
- 
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
+  <interface name="com.citrix.xenclient.networkdomain.config">
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Properties ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <property name="domid" type="u" access="read"/>
+    <property name="is-networking-active" type="b" access="read"/>
+    <property name="name" type="s" access="read"/>
+    <property name="nm-state" type="u" access="read"/>
+    <property name="uuid" type="s" access="read"/>
+  </interface>
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.networkdomain.notify">
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <signal name="backend_state_changed">
-        <tp:docstring>Notifies when a backend starts or stops.</tp:docstring>
-        <arg name="status" type="u"/>
+      <tp:docstring>Notifies when a backend starts or stops.</tp:docstring>
+      <arg name="status" type="u"/>
     </signal>
   </interface>
 </node>

--- a/interfaces/network_interface.xml
+++ b/interfaces/network_interface.xml
@@ -1,31 +1,31 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
-  
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.networkinterface">
-
-    <method name="name">
-      <tp:docstring>Returns the name of the inteface.</tp:docstring>
-      <arg type="s" name="name" direction="out" />
-    </method>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="is_wireless">
       <tp:docstring>Returns true if the interface is wireless.</tp:docstring>
-      <arg type="b" name="is_wireless" direction="out" />
+      <arg type="b" name="is_wireless" direction="out"/>
     </method>
-
-    <method name="mac_address">
-      <tp:docstring>Returns the MAC address of the interface.</tp:docstring>
-      <arg type="s" name="mac" direction="out" />
-    </method>
-
     <method name="list_bridges">
       <tp:docstring>Lists the bridges to connect to use this interface.</tp:docstring>
-      <arg type="a{ss}" name="bridges" direction="out" />
+      <arg type="a{ss}" name="bridges" direction="out"/>
     </method>
-
+    <method name="mac_address">
+      <tp:docstring>Returns the MAC address of the interface.</tp:docstring>
+      <arg type="s" name="mac" direction="out"/>
+    </method>
+    <method name="name">
+      <tp:docstring>Returns the name of the inteface.</tp:docstring>
+      <arg type="s" name="name" direction="out"/>
+    </method>
   </interface>
-
-  <interface name="com.citrix.xenclient.networkinterface.notify">
-  </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
+  <interface name="com.citrix.xenclient.networkinterface.notify"/>
 </node>

--- a/interfaces/network_nm.xml
+++ b/interfaces/network_nm.xml
@@ -1,20 +1,22 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.network.nm">
-
-    <method name="popup_network_menu">
-      <tp:docstring>Signal the NM applet to popup the network menu.</tp:docstring>
-      <arg type="u" name="x_off" direction="in" />
-      <arg type="u" name="y_off" direction="in" />
-    </method>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="close_network_menu">
       <tp:docstring>Signal the NM applet to close the network menu.</tp:docstring>
     </method>
-
     <method name="popup_keyboard">
       <tp:docstring>Pop up the keyboard in the uivm.</tp:docstring>
     </method>
+    <method name="popup_network_menu">
+      <tp:docstring>Signal the NM applet to popup the network menu.</tp:docstring>
+      <arg type="u" name="x_off" direction="in"/>
+      <arg type="u" name="y_off" direction="in"/>
+    </method>
   </interface>
-
 </node>

--- a/interfaces/network_slave.xml
+++ b/interfaces/network_slave.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
   <tp:enum name="CONFIG" type="s">
     <tp:docstring>Network types.</tp:docstring>
     <tp:enumvalue suffix="BRIDGE_FILTERING" value="bridge-filtering"/>
@@ -7,103 +7,93 @@
     <tp:enumvalue suffix="NM_WIRELESS_ENABLED" value="wifi-enabled"/>
     <tp:enumvalue suffix="NM_UNMANAGED_DEVICES" value="unmanaged-devices"/>
   </tp:enum>
-  
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.networkslave">
-
-    <method name="create_internal_networks">
-      <tp:docstring>Method to create internal networks.</tp:docstring>
-      <arg type="u" name="network_number" direction="in" />
-    </method>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="backend_vif_notify">
       <tp:docstring>Method to notify network slave of a new backend VIF.</tp:docstring>
-      <arg type="s" name="vif" direction="in" />
-      <arg type="u" name="domid" direction="in" />
-      <arg type="u" name="devid" direction="in" />
+      <arg type="s" name="vif" direction="in"/>
+      <arg type="u" name="domid" direction="in"/>
+      <arg type="u" name="devid" direction="in"/>
     </method>
-
-    <method name="network_iface_notify">
-      <tp:docstring>Method to notify network slave of the status of a networking interface. </tp:docstring>
-      <arg type="s" name="udev_action" direction="in" />
-      <arg type="s" name="interface" direction="in" />
+    <method name="create_internal_networks">
+      <tp:docstring>Method to create internal networks.</tp:docstring>
+      <arg type="u" name="network_number" direction="in"/>
     </method>
-
+    <method name="get_icavm_network">
+      <tp:docstring>Returns icavm network object.</tp:docstring>
+      <arg type="s" name="icavm_network" direction="out"/>
+    </method>
+    <method name="is_initialized">
+      <tp:docstring>Returns true if the system is initialized.</tp:docstring>
+      <arg type="b" name="is_initialized" direction="out"/>
+    </method>
+    <method name="list_networks">
+      <tp:docstring>Lists networks.</tp:docstring>
+      <arg type="as" name="networks" direction="out"/>
+    </method>
+    <method name="list_vifs">
+      <tp:docstring>Lists backend VIFs.</tp:docstring>
+      <arg type="as" name="vifs" direction="out"/>
+    </method>
     <method name="move_vif_to_network">
       <tp:docstring>Move VIF to network.</tp:docstring>
-      <arg type="s" name="vif" direction="in" />
-      <arg type="s" name="network" direction="in" />
+      <arg type="s" name="vif" direction="in"/>
+      <arg type="s" name="network" direction="in"/>
     </method>
-
+    <method name="network_iface_notify">
+      <tp:docstring>Method to notify network slave of the status of a networking interface. </tp:docstring>
+      <arg type="s" name="udev_action" direction="in"/>
+      <arg type="s" name="interface" direction="in"/>
+    </method>
+    <method name="nm_state">
+      <tp:docstring>Returns network manager state.</tp:docstring>
+      <arg type="u" name="nm_state" direction="out"/>
+    </method>
+    <method name="nw_connectivity">
+      <tp:docstring>Returns true if there is network connectivity.</tp:docstring>
+      <arg type="b" name="is_initialized" direction="out"/>
+    </method>
     <method name="refresh_vifs">
       <tp:docstring>See that all the backend VIFs are connected to the right networks.</tp:docstring>
     </method>
-
     <method name="shutdown">
       <tp:docstring>Shuts down the service.</tp:docstring>
     </method>
-
     <method name="start_nm">
       <tp:docstring>Start Network Manager.</tp:docstring>
     </method>
-
-    <method name="is_initialized">
-      <tp:docstring>Returns true if the system is initialized.</tp:docstring>
-      <arg type="b" name="is_initialized" direction="out" />
-    </method>
-
-    <method name="nw_connectivity">
-      <tp:docstring>Returns true if there is network connectivity.</tp:docstring>
-      <arg type="b" name="is_initialized" direction="out" />
-    </method>
-
-    <method name="list_networks">
-      <tp:docstring>Lists networks.</tp:docstring>
-      <arg type="as" name="networks" direction="out" />
-    </method>
-
-    <method name="list_vifs">
-      <tp:docstring>Lists backend VIFs.</tp:docstring>
-      <arg type="as" name="vifs" direction="out" />
-    </method>
-
-    <method name="get_icavm_network">
-      <tp:docstring>Returns icavm network object.</tp:docstring>
-      <arg type="s" name="icavm_network" direction="out" />
-    </method>
-
-    <method name="nm_state">
-      <tp:docstring>Returns network manager state.</tp:docstring>
-      <arg type="u" name="nm_state" direction="out" />
-    </method>
-
     <method name="vif_added">
       <tp:docstring>Returns whether the vif has been added to a bridge</tp:docstring>
-      <arg type="s" name="vif" direction="in" />
-      <arg type="b" name="added" direction="out" />
+      <arg type="s" name="vif" direction="in"/>
+      <arg type="b" name="added" direction="out"/>
     </method>
-
   </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.networkslave.notify">
-    <signal name="networkslave_up">
-        <tp:docstring>Notifies NWD that the slave is up.</tp:docstring>
-    </signal>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <signal name="network_added">
-        <tp:docstring>Notifies NWD that a new network is added.</tp:docstring>
-        <arg name="network" type="as"/>
+      <tp:docstring>Notifies NWD that a new network is added.</tp:docstring>
+      <arg name="network" type="as"/>
     </signal>
-
     <signal name="network_removed">
-        <tp:docstring>Notifies NWD that a network is no longer available.</tp:docstring>
-        <arg name="network" type="as"/>
+      <tp:docstring>Notifies NWD that a network is no longer available.</tp:docstring>
+      <arg name="network" type="as"/>
     </signal>
-
+    <signal name="networkslave_up">
+      <tp:docstring>Notifies NWD that the slave is up.</tp:docstring>
+    </signal>
     <signal name="new_backend_vif">
-        <tp:docstring>Notifies NWD that a new backend VIF is added.</tp:docstring>
-        <arg name="vif_info" type="as"/>
+      <tp:docstring>Notifies NWD that a new backend VIF is added.</tp:docstring>
+      <arg name="vif_info" type="as"/>
     </signal>
-
   </interface>
-
 </node>

--- a/interfaces/rpc_proxy.xml
+++ b/interfaces/rpc_proxy.xml
@@ -1,62 +1,68 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
-	<interface name="com.citrix.xenclient.rpc_proxy">
-		<tp:docstring></tp:docstring>
-		<method name="validate_call">
-			<arg name="domain" type="i" direction="in">
-				<tp:docstring></tp:docstring>
-			</arg>
-			<arg name="destination" type="s" direction="in">
-				<tp:docstring></tp:docstring>
-			</arg>
-			<arg name="interface" type="s" direction="in">
-				<tp:docstring></tp:docstring>
-			</arg>
-			<arg name="member" type="s" direction="in">
-				<tp:docstring></tp:docstring>
-			</arg>
-			<arg name="r" type="b" direction="out">
-				<tp:docstring></tp:docstring>
-			</arg>
-		</method>
-		<method name="validate_recv_signal">
-			<tp:docstring></tp:docstring>
-			<arg name="domain" type="i" direction="in">
-				<tp:docstring></tp:docstring>
-			</arg>
-			<arg name="interface" type="s" direction="in">
-				<tp:docstring></tp:docstring>
-			</arg>
-			<arg name="member" type="s" direction="in">
-				<tp:docstring></tp:docstring>
-			</arg>
-			<arg name="r" type="b" direction="out">
-				<tp:docstring></tp:docstring>
-			</arg>
-		</method>
-		<method name="validate_send_signal">
-			<tp:docstring></tp:docstring>
-			<arg name="domain" type="i" direction="in">
-				<tp:docstring></tp:docstring>
-			</arg>
-			<arg name="interface" type="s" direction="in">
-				<tp:docstring></tp:docstring>
-			</arg>
-			<arg name="member" type="s" direction="in">
-				<tp:docstring></tp:docstring>
-			</arg>
-			<arg name="r" type="b" direction="out">
-				<tp:docstring></tp:docstring>
-			</arg>
-		</method>
-        <method name="list_rules">
-          <arg name="rules" type="as" direction="out"/>
-        </method>
-        <method name="add_rule">
-          <arg name="rule" type="s" direction="in"/>
-        </method>
-        <method name="delete_rule">
-          <arg name="rule" type="s" direction="in"/>
-        </method>
-	</interface>
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
+  <interface name="com.citrix.xenclient.rpc_proxy">
+    <tp:docstring/>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="add_rule">
+      <arg name="rule" type="s" direction="in"/>
+    </method>
+    <method name="delete_rule">
+      <arg name="rule" type="s" direction="in"/>
+    </method>
+    <method name="list_rules">
+      <arg name="rules" type="as" direction="out"/>
+    </method>
+    <method name="validate_call">
+      <arg name="domain" type="i" direction="in">
+        <tp:docstring/>
+      </arg>
+      <arg name="destination" type="s" direction="in">
+        <tp:docstring/>
+      </arg>
+      <arg name="interface" type="s" direction="in">
+        <tp:docstring/>
+      </arg>
+      <arg name="member" type="s" direction="in">
+        <tp:docstring/>
+      </arg>
+      <arg name="r" type="b" direction="out">
+        <tp:docstring/>
+      </arg>
+    </method>
+    <method name="validate_recv_signal">
+      <tp:docstring/>
+      <arg name="domain" type="i" direction="in">
+        <tp:docstring/>
+      </arg>
+      <arg name="interface" type="s" direction="in">
+        <tp:docstring/>
+      </arg>
+      <arg name="member" type="s" direction="in">
+        <tp:docstring/>
+      </arg>
+      <arg name="r" type="b" direction="out">
+        <tp:docstring/>
+      </arg>
+    </method>
+    <method name="validate_send_signal">
+      <tp:docstring/>
+      <arg name="domain" type="i" direction="in">
+        <tp:docstring/>
+      </arg>
+      <arg name="interface" type="s" direction="in">
+        <tp:docstring/>
+      </arg>
+      <arg name="member" type="s" direction="in">
+        <tp:docstring/>
+      </arg>
+      <arg name="r" type="b" direction="out">
+        <tp:docstring/>
+      </arg>
+    </method>
+  </interface>
 </node>

--- a/interfaces/surfman.xml
+++ b/interfaces/surfman.xml
@@ -1,117 +1,102 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node name="/">
-  <interface name="com.citrix.xenclient.surfman" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
-
-    <method name="notify_death">
-      <arg name="domid" type="i"></arg>
-      <arg name="sstate" type="i"></arg>
-    </method>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
+  <interface xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="com.citrix.xenclient.surfman">
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="create_vgpu">
-      <arg name="domid" type="i" direction="in"></arg>
-      <arg name="bus" type="i"></arg>
-      <arg name="device" type="i"></arg>
-      <arg name="function" type="i"></arg>
+      <arg name="domid" type="i" direction="in"/>
+      <arg name="bus" type="i"/>
+      <arg name="device" type="i"/>
+      <arg name="function" type="i"/>
     </method>
-
-    <method name="update_passthrough_bar">
-      <arg name="domid" type="i"></arg>
-      <arg name="bar" type="i"></arg>
-      <arg name="phys" type="t"></arg>
-      <arg name="base" type="u"></arg>
-      <arg name="size" type="u"></arg>
+    <method name="decrease_brightness"/>
+    <method name="display_image">
+      <arg name="filename" type="s" direction="in"/>
     </method>
-
-    <method name="set_framebuffer_pages">
-      <arg name="domid" type="i"></arg>
-      <arg name="dirty_tracking" type="b"></arg>
-      <arg name="guest_addr" type="t"></arg>
-      <arg name="pages" type="at"></arg>
+    <method name="display_text">
+      <arg name="text" type="s" direction="in"/>
     </method>
-
-    <method name="set_framebuffer_paramters">
-      <arg name="domid" type="i"></arg>
-      <arg name="width" type="i"></arg>
-      <arg name="height" type="i"></arg>
-      <arg name="stride" type="i"></arg>
-      <arg name="format" type="s"></arg>
+    <method name="dpms_off"/>
+    <method name="dpms_on"/>
+    <method name="dump_all_screens">
+      <arg name="directoryname" type="s" direction="in"/>
     </method>
-
-    <method name="set_pv_display">
-      <arg name="domid" type="i"></arg>
-      <arg name="be_type" type="s"></arg>
-    </method>
-
-    <method name="get_stride_alignement">
-        <arg name="stride" type="u" direction="out"></arg>
-    </method>
-
-    <method name="get_heads">
-      <arg name="heads" type="as" direction="out"></arg>
-    </method>
-
     <method name="get_head_resolutions">
-      <arg name="head" type="i" direction="in"></arg>
-      <arg name="resolutions" type="as" direction="out"></arg>
+      <arg name="head" type="i" direction="in"/>
+      <arg name="resolutions" type="as" direction="out"/>
     </method>
-
-    <method name="set_head_resolution">
-      <arg name="head" type="i" direction="in"></arg>
-      <arg name="resolution" type="s" direction="out"></arg>
+    <method name="get_heads">
+      <arg name="heads" type="as" direction="out"/>
     </method>
-
+    <method name="get_stride_alignement">
+      <arg name="stride" type="u" direction="out"/>
+    </method>
+    <method name="get_surfaces_caching">
+      <arg name="caching" type="b" direction="out"/>
+    </method>
     <method name="get_visible">
       <arg name="domids" type="ai" direction="out"/>
     </method>
-
-    <method name="set_visible">
-      <arg name="domid" type="i" direction="in"></arg>
-      <arg name="timeout" type="i" direction="in"></arg>
-      <arg name="force" type="b" direction="in"></arg>
-    </method>
-
-    <method name="dump_all_screens">
-      <arg name="directoryname" type="s" direction="in"></arg>
-    </method>
-
-    <method name="increase_brightness"></method>
-    <method name="decrease_brightness"></method>
-
-    <method name="dpms_on"></method>
-    <method name="dpms_off"></method>
-
-    <method name="pre_s3"></method>
-    <method name="post_s3"></method>
-
-    <method name="vgpu_mode">
-        <arg name="max_vgpus" type="i" direction="out"></arg>
-        <arg name="name" type="s" direction="out"></arg>
-        <arg name="msi_translation" type="b" direction="out"></arg>
-        <arg name="bdfs" type="as" direction="out"></arg>
-    </method>
-
     <method name="has_vgpu">
-        <arg name="domid" type="i" direction="in"></arg>
-        <arg name="enabled" type="b" direction="out"></arg>
+      <arg name="domid" type="i" direction="in"/>
+      <arg name="enabled" type="b" direction="out"/>
     </method>
-
-    <method name="get_surfaces_caching">
-        <arg name="caching" type="b" direction="out"></arg>
+    <method name="increase_brightness"/>
+    <method name="notify_death">
+      <arg name="domid" type="i"/>
+      <arg name="sstate" type="i"/>
     </method>
-
-
-    <method name="display_image">
-        <arg name="filename" type="s" direction="in"></arg>
+    <method name="post_s3"/>
+    <method name="pre_s3"/>
+    <method name="set_framebuffer_pages">
+      <arg name="domid" type="i"/>
+      <arg name="dirty_tracking" type="b"/>
+      <arg name="guest_addr" type="t"/>
+      <arg name="pages" type="at"/>
     </method>
-
-    <method name="display_text">
-        <arg name="text" type="s" direction="in"></arg>
+    <method name="set_framebuffer_paramters">
+      <arg name="domid" type="i"/>
+      <arg name="width" type="i"/>
+      <arg name="height" type="i"/>
+      <arg name="stride" type="i"/>
+      <arg name="format" type="s"/>
     </method>
-
+    <method name="set_head_resolution">
+      <arg name="head" type="i" direction="in"/>
+      <arg name="resolution" type="s" direction="out"/>
+    </method>
+    <method name="set_pv_display">
+      <arg name="domid" type="i"/>
+      <arg name="be_type" type="s"/>
+    </method>
+    <method name="set_visible">
+      <arg name="domid" type="i" direction="in"/>
+      <arg name="timeout" type="i" direction="in"/>
+      <arg name="force" type="b" direction="in"/>
+    </method>
+    <method name="update_passthrough_bar">
+      <arg name="domid" type="i"/>
+      <arg name="bar" type="i"/>
+      <arg name="phys" type="t"/>
+      <arg name="base" type="u"/>
+      <arg name="size" type="u"/>
+    </method>
+    <method name="vgpu_mode">
+      <arg name="max_vgpus" type="i" direction="out"/>
+      <arg name="name" type="s" direction="out"/>
+      <arg name="msi_translation" type="b" direction="out"/>
+      <arg name="bdfs" type="as" direction="out"/>
+    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <signal name="start_service">
-        <tp:docstring>Sent when surfman has started.</tp:docstring>
+      <tp:docstring>Sent when surfman has started.</tp:docstring>
     </signal>
-
     <signal name="visible_domain_changed">
       <tp:docstring>Sent when visible domain has changed.</tp:docstring>
       <arg name="domid" type="i"/>

--- a/interfaces/updatemgr.xml
+++ b/interfaces/updatemgr.xml
@@ -1,13 +1,31 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">      
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.updatemgr">
     <tp:docstring>Primary update manager interface.</tp:docstring>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="apply_update_and_reboot">
+      <tp:docstring>Start the process of applying the update (if update pending, otherwise error). After success, reboot.</tp:docstring>
+    </method>
+    <method name="apply_update_and_shutdown">
+      <tp:docstring>Start the process of applying the update (if update pending, otherwise error). After success, shutdown.</tp:docstring>
+    </method>
+    <method name="cancel_update">
+      <tp:docstring>Cancel the update in progress (if possible, otherwise error).</tp:docstring>
+    </method>
     <method name="check_update">
       <tp:docstring>Download update metadata and check update applicability.</tp:docstring>
       <arg name="url" type="s" direction="in"/>
-      <arg name="version" type="s" direction="out"><tp:docstring>XC version on the server (human-readable).</tp:docstring></arg>
-      <arg name="release" type="s" direction="out"><tp:docstring>XC version on the server (strict format).</tp:docstring></arg>
+      <arg name="version" type="s" direction="out">
+        <tp:docstring>XC version on the server (human-readable).</tp:docstring>
+      </arg>
+      <arg name="release" type="s" direction="out">
+        <tp:docstring>XC version on the server (strict format).</tp:docstring>
+      </arg>
       <arg name="status" type="s" direction="out">
         <tp:docstring><p>Update applicability. Possible values are:</p>
         <ol>
@@ -18,7 +36,6 @@
         </tp:docstring>
       </arg>
     </method>
-
     <method name="check_update_latest">
       <tp:docstring>Treat URL as a repository with multiple updates.
       We expect to find a text file with one URL per line at the given
@@ -30,14 +47,16 @@
 
       Report back on latest applicable update, if any.</tp:docstring>
       <arg name="url" type="s" direction="in"/>
-      <arg name="version" type="s"
-      direction="out"><tp:docstring>Latest applicable (or up-to-date)
+      <arg name="version" type="s" direction="out">
+        <tp:docstring>Latest applicable (or up-to-date)
       XC version on the server (human readable), if avaible.  Empty if
-      no version applicable.</tp:docstring></arg>
-      <arg name="release" type="s"
-      direction="out"><tp:docstring>Latest applicable (or up-to-date)
+      no version applicable.</tp:docstring>
+      </arg>
+      <arg name="release" type="s" direction="out">
+        <tp:docstring>Latest applicable (or up-to-date)
       XC version on the server (strict format), if avaible.  Empty if
-      no version.</tp:docstring></arg>
+      no version.</tp:docstring>
+      </arg>
       <arg name="status" type="s" direction="out">
         <tp:docstring><p>Consolidated update applicability. Possible values are:</p>
         <ol>
@@ -48,35 +67,30 @@
         </tp:docstring>
       </arg>
     </method>
-
     <method name="download_update">
       <tp:docstring>Start the download of the pending update.</tp:docstring>
       <arg name="url" type="s" direction="in"/>
     </method>
-
     <method name="download_update_latest">
       <tp:docstring>Start the download of the latest pending update.
       See documenation for 'check_update_latest' for
       details.</tp:docstring>
       <arg name="url" type="s" direction="in"/>
     </method>
-
-    <method name="apply_update_and_reboot">
-      <tp:docstring>Start the process of applying the update (if update pending, otherwise error). After success, reboot.</tp:docstring>
-    </method>
-
-    <method name="apply_update_and_shutdown">
-      <tp:docstring>Start the process of applying the update (if update pending, otherwise error). After success, shutdown.</tp:docstring>
-    </method>
-
-    <method name="cancel_update">
-      <tp:docstring>Cancel the update in progress (if possible, otherwise error).</tp:docstring>
-    </method>
-
-    <property name="update-url" type="s" access="read">
-      <tp:docstring>Update's URL.</tp:docstring>
-    </property>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <signal name="update_download_progress">
+      <arg name="percent_complete" type="d"/>
+      <arg name="speed" type="d"/>
+    </signal>
+    <signal name="update_state_change">
+      <tp:docstring>Singal that the update state has changed.</tp:docstring>
+      <arg name="state" type="s"/>
+    </signal>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Properties ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <property name="update-applicable" type="s" access="read">
       <tp:docstring><p>Whether currently selected update is applicable or not. Possible values:</p>
       <ol>
@@ -86,7 +100,18 @@
       </ol>
       </tp:docstring>
     </property>
-
+    <property name="update-description" type="s" access="read">
+      <tp:docstring>Description of the pending update.</tp:docstring>
+    </property>
+    <property name="update-download-percent" type="d" access="read">
+      <tp:docstring>Download percentage complete.</tp:docstring>
+    </property>
+    <property name="update-download-speed" type="d" access="read">
+      <tp:docstring>Download speed.</tp:docstring>
+    </property>
+    <property name="update-fail-reason" type="s" access="read">
+      <tp:docstring>Reason of failure in case something went wrong, otherwise empty.</tp:docstring>
+    </property>
     <property name="update-state" type="s" access="read">
       <tp:docstring><p>State of pending update. Possible states are:</p>
       <ol><li>empty string when no update pending/nothing being done</li>
@@ -100,32 +125,8 @@
       </ol>
       </tp:docstring>
     </property>
-
-    <property name="update-description" type="s" access="read">
-      <tp:docstring>Description of the pending update.</tp:docstring>
+    <property name="update-url" type="s" access="read">
+      <tp:docstring>Update's URL.</tp:docstring>
     </property>
-
-    <property name="update-download-percent" type="d" access="read">
-      <tp:docstring>Download percentage complete.</tp:docstring>
-    </property>
-
-    <property name="update-download-speed" type="d" access="read">
-      <tp:docstring>Download speed.</tp:docstring>
-    </property>
-
-    <property name="update-fail-reason" type="s" access="read">
-      <tp:docstring>Reason of failure in case something went wrong, otherwise empty.</tp:docstring>
-    </property>
-
-    <signal name="update_state_change">
-      <tp:docstring>Singal that the update state has changed.</tp:docstring>
-      <arg name="state" type="s"/>
-    </signal>
-
-    <signal name="update_download_progress">
-      <arg name="percent_complete" type="d"/>
-      <arg name="speed" type="d"/>
-    </signal>
-
   </interface>
 </node>

--- a/interfaces/vm_disk.xml
+++ b/interfaces/vm_disk.xml
@@ -1,96 +1,85 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/vm/uuid/disk/id" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
-
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/vm/uuid/disk/id">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.vmdisk">
     <tp:docstring>All disk properties.</tp:docstring>
-    <!-- all disk properties, these are named differently then
-	 the properties in json config (need to change the json config though because names
-	 there are wrong and confusing.
-
-	 list of current properties at the time of writing:
-
-	 backend-uuid     - where the driver lives
-	 phys-path        - path to vhd or /dev/sda1 etc
-	 phys-type        - type: vhd, phy, or others
-	 virt-path        - path the guest sees
-	 mode             - mode
-	 devtype          - either cdrom or disk
-	 snapshot         - snapshot mode
-      -->
-    <property name="backend-uuid" type="s" access="readwrite">
-      <tp:docstring>UUID of the backend VM.</tp:docstring>
-    </property>
-    <property name="backend-name" type="s" access="readwrite">
-      <tp:docstring>Name of the backend VM. Used only if backend-uuid is not set.</tp:docstring>
-    </property>
-    <property name="phys-path" type="s" access="readwrite">
-	  <tp:docstring>Path to VHD or /dev/sda1.</tp:docstring>
-	</property>
-    <property name="phys-type" type="s" access="readwrite">
-	  <tp:docstring>Type: vhd, phy, or others.</tp:docstring>
-	</property>
-    <property name="virt-path" type="s" access="readwrite">
-	  <tp:docstring>Path the guest sees.</tp:docstring>
-	</property>
-    <property name="mode" type="s" access="readwrite">
-	  <tp:docstring>Mode.</tp:docstring>
-	</property>
-    <property name="devtype" type="s" access="readwrite">
-	  <tp:docstring>Either cdrom or disk.</tp:docstring>
-	</property>
-    <property name="snapshot" type="s" access="readwrite">
-	  <tp:docstring>Snapshot mode.</tp:docstring>
-	</property>
-    <property name="shared" type="b" access="readwrite">
-      <tp:docstring>Shared between multiple VMs (circumvents VHD deletion).</tp:docstring>
-    </property>
-    <property name="managed-disktype" type="s" access="readwrite">
-      <tp:docstring>Type of managed disk, if relevant.</tp:docstring>
-    </property>
-    <property name="enabled" type="b" access="readwrite"> <tp:docstring>Disk enabled/disabled flag.</tp:docstring> </property>
-    <property name="encryption-key-set" type="b" access="read"><tp:docstring>Whether this VHD uses encryption key.</tp:docstring></property>
-    <property name="virtual-size-mb" type="i" access="read"><tp:docstring>Virtual size in megabytes.</tp:docstring></property>
-    <property name="utilization-bytes" type="x" access="read"><tp:docstring>Physical utilisation in bytes.</tp:docstring></property>
-
-    <!-- makes this point to VHD image -->
-    <method name="attach_vhd">
-	  <tp:docstring>Makes this point to VHD image.</tp:docstring>
-      <arg name="vhd_path" type="s" direction="in"/>
-    </method>
-
-    <!-- makes this point to physical disk -->
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="attach_phy">
-	  <tp:docstring>Makes this point to physical disk.</tp:docstring>
+      <tp:docstring>Makes this point to physical disk.</tp:docstring>
       <arg name="phy_path" type="s" direction="in"/>
     </method>
-
-    <!-- mount in given directory for easy hacking -->
-    <method name="mount">
-	  <tp:docstring>Mount in given directory for easy hacking.</tp:docstring>
-      <arg name="dirpath" type="s" direction="in"/>
-      <arg name="readonly" type="b" direction="in"/>
+    <method name="attach_vhd">
+      <tp:docstring>Makes this point to VHD image.</tp:docstring>
+      <arg name="vhd_path" type="s" direction="in"/>
     </method>
-
-    <!-- unmount if mounted -->
-    <method name="umount">
-      <tp:docstring>Unmount if mounted.</tp:docstring>
-    </method>
-
-    <!-- detach disk from vm and possibly remove vhd file -->
     <method name="delete">
       <tp:docstring>Detach disk from VM and possibly remove VHD file.</tp:docstring>
     </method>
-
+    <method name="generate_crypto_key">
+      <tp:docstring>Generate VHD's encryption key in platform's key directory.</tp:docstring>
+      <arg name="keysize" type="i" direction="in"/>
+    </method>
     <method name="generate_crypto_key_in">
       <tp:docstring>Generate VHD's encryption key in specified directory.</tp:docstring>
       <arg name="keysize" type="i" direction="in"/>
       <arg name="dirpath" type="s" direction="in"/>
     </method>
-
-    <method name="generate_crypto_key">
-      <tp:docstring>Generate VHD's encryption key in platform's key directory.</tp:docstring>
-      <arg name="keysize" type="i" direction="in"/>
+    <method name="mount">
+      <tp:docstring>Mount in given directory for easy hacking.</tp:docstring>
+      <arg name="dirpath" type="s" direction="in"/>
+      <arg name="readonly" type="b" direction="in"/>
     </method>
+    <method name="umount">
+      <tp:docstring>Unmount if mounted.</tp:docstring>
+    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Properties ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <property name="backend-name" type="s" access="readwrite">
+      <tp:docstring>Name of the backend VM. Used only if backend-uuid is not set.</tp:docstring>
+    </property>
+    <property name="backend-uuid" type="s" access="readwrite">
+      <tp:docstring>UUID of the backend VM.</tp:docstring>
+    </property>
+    <property name="devtype" type="s" access="readwrite">
+      <tp:docstring>Either cdrom or disk.</tp:docstring>
+    </property>
+    <property name="enabled" type="b" access="readwrite">
+      <tp:docstring>Disk enabled/disabled flag.</tp:docstring>
+    </property>
+    <property name="encryption-key-set" type="b" access="read">
+      <tp:docstring>Whether this VHD uses encryption key.</tp:docstring>
+    </property>
+    <property name="managed-disktype" type="s" access="readwrite">
+      <tp:docstring>Type of managed disk, if relevant.</tp:docstring>
+    </property>
+    <property name="mode" type="s" access="readwrite">
+      <tp:docstring>Mode.</tp:docstring>
+    </property>
+    <property name="phys-path" type="s" access="readwrite">
+      <tp:docstring>Path to VHD or /dev/sda1.</tp:docstring>
+    </property>
+    <property name="phys-type" type="s" access="readwrite">
+      <tp:docstring>Type: vhd, phy, or others.</tp:docstring>
+    </property>
+    <property name="shared" type="b" access="readwrite">
+      <tp:docstring>Shared between multiple VMs (circumvents VHD deletion).</tp:docstring>
+    </property>
+    <property name="snapshot" type="s" access="readwrite">
+      <tp:docstring>Snapshot mode.</tp:docstring>
+    </property>
+    <property name="utilization-bytes" type="x" access="read">
+      <tp:docstring>Physical utilisation in bytes.</tp:docstring>
+    </property>
+    <property name="virt-path" type="s" access="readwrite">
+      <tp:docstring>Path the guest sees.</tp:docstring>
+    </property>
+    <property name="virtual-size-mb" type="i" access="read">
+      <tp:docstring>Virtual size in megabytes.</tp:docstring>
+    </property>
   </interface>
-
 </node>

--- a/interfaces/vm_nic.xml
+++ b/interfaces/vm_nic.xml
@@ -1,17 +1,42 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/vm/uuid/nic/id" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
-
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/vm/uuid/nic/id">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.vmnic">
     <tp:docstring>VM Network Interface.</tp:docstring>
-    <property name="backend-uuid" type="s" access="readwrite"> <tp:docstring>UUID of domain holding the driver backend.</tp:docstring> </property>
-    <property name="backend-name" type="s" access="readwrite"> <tp:docstring>Name of domain holding the driver backend. Used only if backend-uuid is not set.</tp:docstring> </property>
-    <property name="network" type="s" access="readwrite"> <tp:docstring>Network identifier.</tp:docstring> </property>
-    <property name="wireless-driver" type="b" access="readwrite"> <tp:docstring>Use wireless driver for this interface.</tp:docstring></property>
-    <property name="mac" type="s" access="readwrite"> <tp:docstring>Specify MAC address, or 'auto'.</tp:docstring> </property>
-    <property name="mac-actual" type="s" access="read"> <tp:docstring>MAC address.</tp:docstring> </property>
-    <property name="enabled" type="b" access="readwrite"> <tp:docstring>Interface enabled/disabled flag.</tp:docstring> </property>
-    <property name="model" type="s" access="readwrite"> <tp:docstring>Model for emulated nic.</tp:docstring> </property>
-    <method name="delete"> <tp:docstring>Delete NIC.</tp:docstring> </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="delete">
+      <tp:docstring>Delete NIC.</tp:docstring>
+    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Properties ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <property name="backend-name" type="s" access="readwrite">
+      <tp:docstring>Name of domain holding the driver backend. Used only if backend-uuid is not set.</tp:docstring>
+    </property>
+    <property name="backend-uuid" type="s" access="readwrite">
+      <tp:docstring>UUID of domain holding the driver backend.</tp:docstring>
+    </property>
+    <property name="enabled" type="b" access="readwrite">
+      <tp:docstring>Interface enabled/disabled flag.</tp:docstring>
+    </property>
+    <property name="mac" type="s" access="readwrite">
+      <tp:docstring>Specify MAC address, or 'auto'.</tp:docstring>
+    </property>
+    <property name="mac-actual" type="s" access="read">
+      <tp:docstring>MAC address.</tp:docstring>
+    </property>
+    <property name="model" type="s" access="readwrite">
+      <tp:docstring>Model for emulated nic.</tp:docstring>
+    </property>
+    <property name="network" type="s" access="readwrite">
+      <tp:docstring>Network identifier.</tp:docstring>
+    </property>
+    <property name="wireless-driver" type="b" access="readwrite">
+      <tp:docstring>Use wireless driver for this interface.</tp:docstring>
+    </property>
   </interface>
-
 </node>

--- a/interfaces/xcpmd.xml
+++ b/interfaces/xcpmd.xml
@@ -1,8 +1,12 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
-  
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.xcpmd">
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="add_rule">
       <tp:docstring>Adds a rule to the policy.</tp:docstring>
       <arg type="s" name="name" direction="in">
@@ -25,47 +29,6 @@
         </tp:docstring>
       </arg>
     </method>
-
-    <method name="remove_rule">
-      <tp:docstring>Removes the rule with the specified name from
-        the policy.
-      </tp:docstring>
-      <arg type="s" name="rule_name" direction="in">
-        <tp:docstring>The name of the rule to be removed.
-        </tp:docstring>
-      </arg>
-    </method>
-
-    <method name="load_policy_from_db">
-      <tp:docstring>Loads the rules and variables available in the DB.
-      </tp:docstring>
-    </method>
-
-    <method name="load_policy_from_file">
-      <tp:docstring>Loads a set of rules and variables from the specified file.
-      </tp:docstring>
-      <arg type="s" name="filename" direction="in">
-        <tp:docstring>Absolute path to the policy file.
-        </tp:docstring>
-      </arg>
-    </method>
-
-    <method name="clear_policy">
-      <tp:docstring>Removes all loaded rules and variables.
-      </tp:docstring>
-    </method>
-
-    <method name="clear_rules">
-      <tp:docstring>Removes all loaded rules.
-      </tp:docstring>
-    </method>
-
-    <method name="clear_vars">
-      <tp:docstring>Removes all loaded variables that are not currently being
-        used by rules.
-      </tp:docstring>
-    </method>
-
     <method name="add_var">
       <tp:docstring>Adds or overwrites a variable.</tp:docstring>
       <arg type="s" name="name" direction="in">
@@ -77,51 +40,30 @@
         </tp:docstring>
       </arg>
     </method>
-
-    <method name="remove_var">
-      <tp:docstring>Removes a variable.</tp:docstring>
-      <arg type="s" name="name" direction="in">
-        <tp:docstring>The name of the variable to be removed.
-        </tp:docstring>
-      </arg>
-    </method>
-
-    <method name="get_conditions">
-      <tp:docstring>Returns the list of currently available 
-        conditions.</tp:docstring>
-      <arg type="as" name="conditions" direction="out">
-        <tp:docstring>An array of human-readable descriptions
-          of currently available conditions.</tp:docstring>
-      </arg>
-    </method>
-
-    <method name="get_actions">
-      <tp:docstring>Returns the list of currently available 
-        actions.</tp:docstring>
-      <arg type="as" name="actions" direction="out">
-        <tp:docstring>An array of human-readable descriptions
-          of currently available actions.</tp:docstring>
-      </arg>
-    </method>
-
-    <method name="get_rules">
-      <tp:docstring>Returns the list of currently loaded rules.
+    <method name="aggregate_battery_percentage">
+      <tp:docstring>Returns the remaining charge in percent for the whole system.
       </tp:docstring>
-      <arg type="as" name="rules" direction="out">
-        <tp:docstring>An array of human-readable descriptions
-          of currently loaded rules.</tp:docstring>
-      </arg>
+      <arg type="u" name="percentage" direction="out"/>
     </method>
-
-    <method name="get_vars">
-      <tp:docstring>Returns the list of currently loaded variables.
+    <method name="aggregate_battery_state">
+      <tp:docstring>Returns the charge/discharge state of the whole system, as
+        in http://upower.freedesktop.org/docs/Device.html#Device:State.
       </tp:docstring>
-      <arg type="as" name="vars" direction="out">
-        <tp:docstring>An array of human-readable descriptions
-          of currently loaded variables.</tp:docstring>
-      </arg>
+      <arg type="u" name="state" direction="out"/>
     </method>
-              
+    <method name="aggregate_battery_time_to_empty">
+      <tp:docstring>Returns the number of seconds until all batteries in the
+        system have fully discharged, or 0 if the system isn't currently
+        discharging.
+      </tp:docstring>
+      <arg type="u" name="time_to_empty" direction="out"/>
+    </method>
+    <method name="aggregate_battery_time_to_full">
+      <tp:docstring>Returns the number of seconds until all batteries in the
+        system have fully charged, or 0 if the system isn't currently charging.
+      </tp:docstring>
+      <arg type="u" name="time_to_full" direction="out"/>
+    </method>
     <method name="batteries_present">
       <tp:docstring>Returns a list of indices of the batteries currently present.
       </tp:docstring>
@@ -130,159 +72,183 @@
         </tp:docstring>
       </arg>
     </method>
-
-    <method name="battery_time_to_empty">
-      <tp:docstring>Returns when bat_n will be empty, in seconds, or 0
-      if the battery is not currently discharging</tp:docstring>
+    <method name="battery_is_present">
+      <tp:docstring>Returns the presence of bat_n</tp:docstring>
       <arg type="u" name="bat_n" direction="in">
-	<tp:docstring>The battery ID, most likely 0 or 1</tp:docstring>
+        <tp:docstring>The battery ID, most likely 0 or 1</tp:docstring>
       </arg>
-      <arg type="u" name="time_to_empty" direction="out" />
+      <arg type="b" name="is_present" direction="out"/>
     </method>
-
-    <method name="battery_time_to_full">
-      <tp:docstring>Returns when bat_n will be full, in seconds, or 0
-      if the battery is not currently charging</tp:docstring>
-      <arg type="u" name="bat_n" direction="in">
-	<tp:docstring>The battery ID, most likely 0 or 1</tp:docstring>
-      </arg>
-      <arg type="u" name="time_to_full" direction="out" />
-    </method>
-
     <method name="battery_percentage">
       <tp:docstring>Returns the remaining charge in percents for
       bat_n</tp:docstring>
       <arg type="u" name="bat_n" direction="in">
-	<tp:docstring>The battery ID, most likely 0 or 1</tp:docstring>
+        <tp:docstring>The battery ID, most likely 0 or 1</tp:docstring>
       </arg>
-      <arg type="u" name="percentage" direction="out" />
+      <arg type="u" name="percentage" direction="out"/>
     </method>
-
-    <method name="battery_is_present">
-      <tp:docstring>Returns the presence of bat_n</tp:docstring>
-      <arg type="u" name="bat_n" direction="in">
-	<tp:docstring>The battery ID, most likely 0 or 1</tp:docstring>
-      </arg>
-      <arg type="b" name="is_present" direction="out" />
-    </method>
-
     <method name="battery_state">
       <tp:docstring>Returns the state of bat_n. For the values, see
       http://upower.freedesktop.org/docs/Device.html#Device:State</tp:docstring>
       <arg type="u" name="bat_n" direction="in">
-	<tp:docstring>The battery ID, most likely 0 or 1</tp:docstring>
+        <tp:docstring>The battery ID, most likely 0 or 1</tp:docstring>
       </arg>
-      <arg type="u" name="state" direction="out" />
+      <arg type="u" name="state" direction="out"/>
     </method>
-
-    <method name="aggregate_battery_percentage">
-      <tp:docstring>Returns the remaining charge in percent for the whole system.
+    <method name="battery_time_to_empty">
+      <tp:docstring>Returns when bat_n will be empty, in seconds, or 0
+      if the battery is not currently discharging</tp:docstring>
+      <arg type="u" name="bat_n" direction="in">
+        <tp:docstring>The battery ID, most likely 0 or 1</tp:docstring>
+      </arg>
+      <arg type="u" name="time_to_empty" direction="out"/>
+    </method>
+    <method name="battery_time_to_full">
+      <tp:docstring>Returns when bat_n will be full, in seconds, or 0
+      if the battery is not currently charging</tp:docstring>
+      <arg type="u" name="bat_n" direction="in">
+        <tp:docstring>The battery ID, most likely 0 or 1</tp:docstring>
+      </arg>
+      <arg type="u" name="time_to_full" direction="out"/>
+    </method>
+    <method name="clear_policy">
+      <tp:docstring>Removes all loaded rules and variables.
       </tp:docstring>
-      <arg type="u" name="percentage" direction="out" />
     </method>
-
-    <method name="aggregate_battery_state">
-      <tp:docstring>Returns the charge/discharge state of the whole system, as
-        in http://upower.freedesktop.org/docs/Device.html#Device:State.
+    <method name="clear_rules">
+      <tp:docstring>Removes all loaded rules.
       </tp:docstring>
-      <arg type="u" name="state" direction="out" />
     </method>
-
-    <method name="aggregate_battery_time_to_empty">
-      <tp:docstring>Returns the number of seconds until all batteries in the
-        system have fully discharged, or 0 if the system isn't currently
-        discharging.
+    <method name="clear_vars">
+      <tp:docstring>Removes all loaded variables that are not currently being
+        used by rules.
       </tp:docstring>
-      <arg type="u" name="time_to_empty" direction="out" />
     </method>
-
-    <method name="aggregate_battery_time_to_full">
-      <tp:docstring>Returns the number of seconds until all batteries in the
-        system have fully charged, or 0 if the system isn't currently charging.
-      </tp:docstring>
-      <arg type="u" name="time_to_full" direction="out" />
-    </method>
-
     <method name="get_ac_adapter_state">
       <tp:docstring>Returns AC adapter state.  A value of 1 means AC adapter in use, else 0.</tp:docstring>
-      <arg type="u" name="ac_ret" direction="out" />
+      <arg type="u" name="ac_ret" direction="out"/>
     </method>
-
-    <method name="get_current_battery_level">
-      <tp:docstring>Returns current battery level. 0 when normal, 1 for warning, 2 for low and 3 for critical.</tp:docstring>
-      <arg type="u" name="battery_level" direction="out" />           
-    </method>
-
-    <method name="get_current_temperature">
-      <tp:docstring>Returns current platform temperature.</tp:docstring>
-      <arg type="u" name="cur_temp_ret" direction="out" />
-    </method>
-
-    <method name="get_critical_temperature">
-      <tp:docstring>Returns current critical platform temperature.</tp:docstring>
-      <arg type="u" name="crit_temp_ret" direction="out" />       
-    </method>
-
-    <method name="get_bif">
-      <tp:docstring>Returns battery information as string.</tp:docstring>
-      <arg type="s" name="bif_ret" direction="out" /> 
-    </method>
-
-    <method name="get_bst">
-      <tp:docstring>Returns battery status as string.</tp:docstring>
-      <arg type="s" name="bst_ret" direction="out" />       
-    </method>
-
-    <method name="indicate_input">
-      <tp:docstring>Called to indicate KB and other input values of interest.</tp:docstring>
-      <arg type="i" name="input_value" direction="in">
-        <tp:docstring>Input values (since enum not implemented): INPUT_SLEEP=1 INPUT_BRIGHTNESSUP=2 INPUT_BRIGHTNESSDOWN=3.</tp:docstring>
+    <method name="get_actions">
+      <tp:docstring>Returns the list of currently available 
+        actions.</tp:docstring>
+      <arg type="as" name="actions" direction="out">
+        <tp:docstring>An array of human-readable descriptions
+          of currently available actions.</tp:docstring>
       </arg>
     </method>
-
+    <method name="get_bif">
+      <tp:docstring>Returns battery information as string.</tp:docstring>
+      <arg type="s" name="bif_ret" direction="out"/>
+    </method>
+    <method name="get_bst">
+      <tp:docstring>Returns battery status as string.</tp:docstring>
+      <arg type="s" name="bst_ret" direction="out"/>
+    </method>
+    <method name="get_conditions">
+      <tp:docstring>Returns the list of currently available 
+        conditions.</tp:docstring>
+      <arg type="as" name="conditions" direction="out">
+        <tp:docstring>An array of human-readable descriptions
+          of currently available conditions.</tp:docstring>
+      </arg>
+    </method>
+    <method name="get_critical_temperature">
+      <tp:docstring>Returns current critical platform temperature.</tp:docstring>
+      <arg type="u" name="crit_temp_ret" direction="out"/>
+    </method>
+    <method name="get_current_battery_level">
+      <tp:docstring>Returns current battery level. 0 when normal, 1 for warning, 2 for low and 3 for critical.</tp:docstring>
+      <arg type="u" name="battery_level" direction="out"/>
+    </method>
+    <method name="get_current_temperature">
+      <tp:docstring>Returns current platform temperature.</tp:docstring>
+      <arg type="u" name="cur_temp_ret" direction="out"/>
+    </method>
+    <method name="get_rules">
+      <tp:docstring>Returns the list of currently loaded rules.
+      </tp:docstring>
+      <arg type="as" name="rules" direction="out">
+        <tp:docstring>An array of human-readable descriptions
+          of currently loaded rules.</tp:docstring>
+      </arg>
+    </method>
+    <method name="get_vars">
+      <tp:docstring>Returns the list of currently loaded variables.
+      </tp:docstring>
+      <arg type="as" name="vars" direction="out">
+        <tp:docstring>An array of human-readable descriptions
+          of currently loaded variables.</tp:docstring>
+      </arg>
+    </method>
     <method name="hotkey_switch">
       <tp:docstring>Called to switch hotkey mapping values.</tp:docstring>
       <arg type="b" name="reset" direction="in">
         <tp:docstring>TRUE to reset to boot time value, FALSE to set to platform specific value</tp:docstring>
       </arg>
     </method>
-
-    <signal name="num_batteries_changed">
-      <tp:docstring>Signals change in number of batteries present.</tp:docstring>
-    </signal>
-
+    <method name="indicate_input">
+      <tp:docstring>Called to indicate KB and other input values of interest.</tp:docstring>
+      <arg type="i" name="input_value" direction="in">
+        <tp:docstring>Input values (since enum not implemented): INPUT_SLEEP=1 INPUT_BRIGHTNESSUP=2 INPUT_BRIGHTNESSDOWN=3.</tp:docstring>
+      </arg>
+    </method>
+    <method name="load_policy_from_db">
+      <tp:docstring>Loads the rules and variables available in the DB.
+      </tp:docstring>
+    </method>
+    <method name="load_policy_from_file">
+      <tp:docstring>Loads a set of rules and variables from the specified file.
+      </tp:docstring>
+      <arg type="s" name="filename" direction="in">
+        <tp:docstring>Absolute path to the policy file.
+        </tp:docstring>
+      </arg>
+    </method>
+    <method name="remove_rule">
+      <tp:docstring>Removes the rule with the specified name from
+        the policy.
+      </tp:docstring>
+      <arg type="s" name="rule_name" direction="in">
+        <tp:docstring>The name of the rule to be removed.
+        </tp:docstring>
+      </arg>
+    </method>
+    <method name="remove_var">
+      <tp:docstring>Removes a variable.</tp:docstring>
+      <arg type="s" name="name" direction="in">
+        <tp:docstring>The name of the variable to be removed.
+        </tp:docstring>
+      </arg>
+    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <signal name="ac_adapter_state_changed">
       <tp:docstring>Signals change in platform AC adapter status.</tp:docstring>
     </signal>
-
+    <signal name="battery_info_changed">
+      <tp:docstring>Signals change in platform battery information.</tp:docstring>
+    </signal>
+    <signal name="battery_level_notification">
+      <tp:docstring>Signals when battery level changes from normal.</tp:docstring>
+    </signal>
     <signal name="battery_status_changed">
       <tp:docstring>Signals change in platform battery status.</tp:docstring>
     </signal>
-
-    <signal name="battery_info_changed">
-      <tp:docstring>Signals change in platform battery information.</tp:docstring>      
+    <signal name="bcl_key_pressed">
+      <tp:docstring>Signals when brightness control hotkeys are pressed.</tp:docstring>
     </signal>
-
-    <signal name="power_button_pressed">
-      <tp:docstring>Signals when power button is pressed.</tp:docstring>
+    <signal name="num_batteries_changed">
+      <tp:docstring>Signals change in number of batteries present.</tp:docstring>
     </signal>
-
-    <signal name="sleep_button_pressed">
-      <tp:docstring>Signals when sleep button is pressed.</tp:docstring>
-    </signal>
-
     <signal name="oem_event_triggered">
       <tp:docstring>Signals when OEM special buttons/hotkeys are pressed.</tp:docstring>
     </signal>
-
-    <signal name="battery_level_notification">
-      <tp:docstring>Signals when battery level changes from normal.</tp:docstring>        
-     </signal>
-
-    <signal name="bcl_key_pressed">
-      <tp:docstring>Signals when brightness control hotkeys are pressed.</tp:docstring>   
+    <signal name="power_button_pressed">
+      <tp:docstring>Signals when power button is pressed.</tp:docstring>
     </signal>
-
+    <signal name="sleep_button_pressed">
+      <tp:docstring>Signals when sleep button is pressed.</tp:docstring>
+    </signal>
   </interface>
-
 </node>

--- a/interfaces/xenmgr.xml
+++ b/interfaces/xenmgr.xml
@@ -1,5 +1,26 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/">
+  <tp:enum name="MANAGED_DISKTYPE" type="s">
+    <tp:docstring>Managed disk type.</tp:docstring>
+    <tp:enumvalue suffix="NONE" value=""/>
+    <tp:enumvalue suffix="SYSTEM" value="system"/>
+    <tp:enumvalue suffix="APPLICATION" value="application"/>
+    <tp:enumvalue suffix="USER" value="user"/>
+  </tp:enum>
+  <tp:enum name="S3_MODE" type="s">
+    <tp:docstring>S3 mode.</tp:docstring>
+    <tp:enumvalue suffix="PV" value="pv"/>
+    <tp:enumvalue suffix="IGNORE" value="ignore"/>
+    <tp:enumvalue suffix="RESTART" value="restart"/>
+    <tp:enumvalue suffix="SNAPSHOT" value="snapshot"/>
+  </tp:enum>
+  <tp:enum name="S4_MODE" type="s">
+    <tp:docstring>S4 mode.</tp:docstring>
+    <tp:enumvalue suffix="PV" value="pv"/>
+    <tp:enumvalue suffix="IGNORE" value="ignore"/>
+    <tp:enumvalue suffix="RESTART" value="restart"/>
+    <tp:enumvalue suffix="SNAPSHOT" value="snapshot"/>
+  </tp:enum>
   <tp:enum name="VM_STATE" type="s">
     <tp:docstring>VM lifecycle state codes.</tp:docstring>
     <tp:enumvalue suffix="CREATING" value="creating"/>
@@ -14,103 +35,57 @@
     <tp:enumvalue suffix="RESTORING" value="restoring"/>
     <tp:enumvalue suffix="PAUSED" value="paused"/>
   </tp:enum>
-
-  <tp:enum name="MANAGED_DISKTYPE" type="s">
-    <tp:docstring>Managed disk type.</tp:docstring>
-    <tp:enumvalue suffix="NONE" value=""/>
-    <tp:enumvalue suffix="SYSTEM" value="system"/>
-    <tp:enumvalue suffix="APPLICATION" value="application"/>
-    <tp:enumvalue suffix="USER" value="user"/>
-  </tp:enum>
-
-  <tp:enum name="S3_MODE" type="s">
-    <tp:docstring>S3 mode.</tp:docstring>
-    <tp:enumvalue suffix="PV" value="pv"/>
-    <tp:enumvalue suffix="IGNORE" value="ignore"/>
-    <tp:enumvalue suffix="RESTART" value="restart"/>
-    <tp:enumvalue suffix="SNAPSHOT" value="snapshot"/>
-  </tp:enum>
-
-  <tp:enum name="S4_MODE" type="s">
-    <tp:docstring>S4 mode.</tp:docstring>
-    <tp:enumvalue suffix="PV" value="pv"/>
-    <tp:enumvalue suffix="IGNORE" value="ignore"/>
-    <tp:enumvalue suffix="RESTART" value="restart"/>
-    <tp:enumvalue suffix="SNAPSHOT" value="snapshot"/>
-  </tp:enum>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
+  <interface name="com.citrix.xenclient.policy">
+    <tp:docstring>Implements the policy enforce/retrieve.</tp:docstring>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="enforce">
+      <arg name="uuid" type="s" direction="in"/>
+      <arg name="value" type="s" direction="in"/>
+    </method>
+    <method name="retrieve">
+      <arg name="uuid" type="s" direction="in"/>
+      <arg name="result" type="s" direction="out"/>
+    </method>
+  </interface>
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.xenmgr">
     <tp:docstring>Main xenmgr interface, used for VM creation and enumeration.</tp:docstring>
-
-    <method name="list_vms">
-      <tp:docstring>List each VM present. Returns a list of dicts with few critical properties filled for each VM, including VM state, domain ID (if running), uuid etc.</tp:docstring>
-      <arg name="paths" type="ao" direction="out"/>
-    </method> 
-
-    <method name="list_domids">
-      <tp:docstring>List current domain IDs.</tp:docstring>
-      <arg name="domids" type="ai" direction="out"/>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="create_vhd">
+      <tp:docstring>Create a new VHD.</tp:docstring>
+      <arg name="size_mb" type="i" direction="in"/>
+      <arg name="path" type="s" direction="out"/>
     </method>
-
-    <method name="list_child_service_vm_templates">
-      <tp:docstring>List the templates for creating child service VMs.</tp:docstring>
-      <arg name="templates" type="as" direction="out"/>
-    </method>
-
-    <method name="list_templates">
-      <tp:docstring>List the templates for creating new VMa.</tp:docstring>
-      <arg name="templates" type="as" direction="out"/>
-    </method>
-
-    <method name="list_ui_templates">
-      <tp:docstring>List the UI-visible VM creation templates.</tp:docstring>
-      <arg name="templates" type="aa{ss}" direction="out"/>
-    </method>
-
-    <method name="list_extension_packs">
-      <tp:docstring>List installed extension packs. Returns array of dictionaries, where each dict contains following keys:
-	vendor, name, description, version, image.
-      </tp:docstring>
-      <arg name="packs" type="aa{ss}" direction="out"/>
-    </method>
-
-    <method name="find_vm_by_uuid">
-      <tp:docstring>Returns the object path to the VM with the given UUID, or raises an error.</tp:docstring>
-      <arg name="uuid" type="s" direction="in"/>
-      <arg name="obj_path" type="o" direction="out"/>
-    </method>
-
-    <method name="find_vm_by_domid">
-      <tp:docstring>Returns the object path to the VM of the given domain ID. Fails with an error if no such VM is running.</tp:docstring>
-      <arg name="domid" type="i" direction="in"/>
-      <arg name="obj_path" type="o" direction="out"/>
-    </method>
-
     <method name="create_vm">
       <tp:docstring>Create a new VM.</tp:docstring>
       <arg name="path" type="o" direction="out"/>
     </method>
-
     <method name="create_vm_with_template">
       <tp:docstring>Create a new VM based on the given template.</tp:docstring>
       <arg name="template" type="s" direction="in"/>
       <arg name="path" type="o" direction="out"/>
     </method>
-
-    <method name="create_vm_with_template_and_uuid">
-      <tp:docstring>Create a new VM based on the given template and UUID.</tp:docstring>
-      <arg name="template" type="s" direction="in"/>
-      <arg name="uuid" type="s" direction="in"/>
-      <arg name="path" type="o" direction="out"/>
-    </method>
-
     <method name="create_vm_with_template_and_json">
       <tp:docstring>Create a new VM based on given template file and JSON blob. Template or json can be left empty</tp:docstring>
       <arg name="template" type="s" direction="in"/>
       <arg name="json" type="s" direction="in"/>
       <arg name="path" type="o" direction="out"/>
     </method>
-
+    <method name="create_vm_with_template_and_uuid">
+      <tp:docstring>Create a new VM based on the given template and UUID.</tp:docstring>
+      <arg name="template" type="s" direction="in"/>
+      <arg name="uuid" type="s" direction="in"/>
+      <arg name="path" type="o" direction="out"/>
+    </method>
     <method name="create_vm_with_ui">
       <tp:docstring>Create a new VM based on the given template, with ui properties initially set.</tp:docstring>
       <arg name="template" type="s" direction="in"/>
@@ -119,25 +94,86 @@
       <arg name="image_path" type="s" direction="in"/>
       <arg name="path" type="o" direction="out"/>
     </method>
-
-    <method name="create_vhd">
-      <tp:docstring>Create a new VHD.</tp:docstring>
-      <arg name="size_mb" type="i" direction="in"/>
-      <arg name="path" type="s" direction="out"/>
+    <method name="find_vm_by_domid">
+      <tp:docstring>Returns the object path to the VM of the given domain ID. Fails with an error if no such VM is running.</tp:docstring>
+      <arg name="domid" type="i" direction="in"/>
+      <arg name="obj_path" type="o" direction="out"/>
     </method>
-
+    <method name="find_vm_by_uuid">
+      <tp:docstring>Returns the object path to the VM with the given UUID, or raises an error.</tp:docstring>
+      <arg name="uuid" type="s" direction="in"/>
+      <arg name="obj_path" type="o" direction="out"/>
+    </method>
+    <method name="list_child_service_vm_templates">
+      <tp:docstring>List the templates for creating child service VMs.</tp:docstring>
+      <arg name="templates" type="as" direction="out"/>
+    </method>
+    <method name="list_domids">
+      <tp:docstring>List current domain IDs.</tp:docstring>
+      <arg name="domids" type="ai" direction="out"/>
+    </method>
+    <method name="list_extension_packs">
+      <tp:docstring>List installed extension packs. Returns array of dictionaries, where each dict contains following keys:
+	vendor, name, description, version, image.
+      </tp:docstring>
+      <arg name="packs" type="aa{ss}" direction="out"/>
+    </method>
+    <method name="list_templates">
+      <tp:docstring>List the templates for creating new VMa.</tp:docstring>
+      <arg name="templates" type="as" direction="out"/>
+    </method>
+    <method name="list_ui_templates">
+      <tp:docstring>List the UI-visible VM creation templates.</tp:docstring>
+      <arg name="templates" type="aa{ss}" direction="out"/>
+    </method>
+    <method name="list_vms">
+      <tp:docstring>List each VM present. Returns a list of dicts with few critical properties filled for each VM, including VM state, domain ID (if running), uuid etc.</tp:docstring>
+      <arg name="paths" type="ao" direction="out"/>
+    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <signal name="cd_assignment_changed">
+      <tp:docstring>CD device VM assignment has changed.</tp:docstring>
+      <arg name="dev" type="s"/>
+      <arg name="uuid" type="s"/>
+      <arg name="obj_path" type="o"/>
+    </signal>
+    <signal name="config_changed">
+      <tp:docstring>Notify xenmgr that host level configuration has changed.</tp:docstring>
+    </signal>
+    <signal name="language_changed">
+      <tp:docstring>Notify that the language settings have changed.</tp:docstring>
+    </signal>
+    <signal name="network_state_changed">
+      <tp:docstring>Notify when a network becomes available/unavailable.</tp:docstring>
+      <arg name="available" type="b"/>
+    </signal>
+    <signal name="notify">
+      <tp:docstring>Send out generic notification, details inside string arg.</tp:docstring>
+      <arg name="uuid" type="s"/>
+      <arg name="messsage" type="s"/>
+    </signal>
     <signal name="vm_config_changed">
       <tp:docstring>Notify that VM configuration has changed.</tp:docstring>
       <arg name="uuid" type="s"/>
       <arg name="obj_path" type="o"/>
     </signal>
-	
-	<signal name="notify">
-	  <tp:docstring>Send out generic notification, details inside string arg.</tp:docstring>
-	  <arg name="uuid" type="s"/>
-	  <arg name="messsage" type="s"/>
-	</signal>
-
+    <signal name="vm_created">
+      <tp:docstring>Notify that a VM was created.</tp:docstring>
+      <arg name="uuid" type="s"/>
+      <arg name="obj_path" type="o"/>
+    </signal>
+    <signal name="vm_deleted">
+      <tp:docstring>Notify that a VM was deleted.</tp:docstring>
+      <arg name="uuid" type="s"/>
+      <arg name="obj_path" type="o"/>
+    </signal>
+    <signal name="vm_name_changed">
+      <tp:docstring>Notify that VM name has changed.</tp:docstring>
+      <arg name="uuid" type="s"/>
+      <arg name="obj_path" type="o"/>
+    </signal>
     <signal name="vm_state_changed">
       <tp:docstring>Notify that VM state has changed.</tp:docstring>
       <arg name="uuid" type="s"/>
@@ -145,194 +181,132 @@
       <arg name="state" type="s"/>
       <arg name="acpi_state" type="i"/>
     </signal>
-
-    <signal name="vm_name_changed">
-      <tp:docstring>Notify that VM name has changed.</tp:docstring>
-      <arg name="uuid" type="s"/>
-      <arg name="obj_path" type="o"/>
-    </signal>
-
-    <signal name="config_changed">
-      <tp:docstring>Notify xenmgr that host level configuration has changed.</tp:docstring>
-    </signal>
-
-    <signal name="language_changed">
-      <tp:docstring>Notify that the language settings have changed.</tp:docstring>
-    </signal>
-
-    <signal name="vm_created">
-      <tp:docstring>Notify that a VM was created.</tp:docstring>
-      <arg name="uuid" type="s"/>
-      <arg name="obj_path" type="o"/>
-    </signal>
-
-    <signal name="vm_deleted">
-      <tp:docstring>Notify that a VM was deleted.</tp:docstring>
-      <arg name="uuid" type="s"/>
-      <arg name="obj_path" type="o"/>
-    </signal>
-
-    <signal name="network_state_changed">
-      <tp:docstring>Notify when a network becomes available/unavailable.</tp:docstring>
-      <arg name="available" type="b"/>
-    </signal>
-
     <signal name="vm_transfer_changed">
       <tp:docstring>VM download/upload progress has changed.</tp:docstring>
       <arg name="uuid" type="s"/>
       <arg name="obj_path" type="o"/>
     </signal>
-
-    <signal name="cd_assignment_changed">
-      <tp:docstring>CD device VM assignment has changed.</tp:docstring>
-      <arg name="dev" type="s"/>
-      <arg name="uuid" type="s"/>
-      <arg name="obj_path" type="o"/>
-    </signal>
   </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.xenmgr.config">
     <tp:docstring>xenmgr configuration information, mostly living in the /xenmgr db tree.</tp:docstring>
-    <property name="iso-path" type="s" access="readwrite"/>
-    <property name="autostart" type="b" access="readwrite"/>
-    <property name="pvm-autostart-delay" type="i" access="readwrite"/>
-    <property name="svm-autostart-delay" type="i" access="readwrite"/>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Properties ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <property name="argo-firewall" type="b" access="readwrite">
+      <tp:docstring>If true, argo firewall is enabled, rejecting all incoming traffic by default.</tp:docstring>
+    </property>
     <property name="argo-hosts-file" type="b" access="readwrite"/>
-    <property name="use-networking-domain" type="b" access="read"/>
+    <property name="autolock-cd-drives" type="b" access="readwrite">
+      <tp:docstring>Automatically lock/unlock cd drives to vms on media insert/eject events</tp:docstring>
+    </property>
+    <property name="autostart" type="b" access="readwrite"/>
     <property name="bypass-sha1sum-checks" type="b" access="read"/>
-    <property name="xc-diag-timeout" type="i" access="readwrite"/>
-    <property name="platform-crypto-key-dirs" type="s" access="readwrite">
-      <tp:docstring>Comma separated list of disk encryption keys directories.</tp:docstring>
+    <property name="configurable-save-changes-across-reboots" type="b" access="read">
+      <tp:docstring>True if user can opt to not save VHD changes across VM reboot.</tp:docstring>
+    </property>
+    <property name="connect-remote-desktop-allowed" type="b" access="readwrite">
+      <tp:docstring>Allow using remote desktop (via icavm).</tp:docstring>
+    </property>
+    <property name="dom0-mem-target-mib" type="i" access="readwrite">
+      <tp:docstring>Dom0 balloon memory target, in mebibytes. If 0, don't balloon dom0.</tp:docstring>
+    </property>
+    <property name="enable-argo-ssh" type="b" access="readwrite">
+      <tp:docstring>Enable internal SSH access to dom0.</tp:docstring>
+    </property>
+    <property name="enable-dom0-networking" type="b" access="readwrite">
+      <tp:docstring>Have dom0 connect to external network using DHCP.</tp:docstring>
+    </property>
+    <property name="enable-ssh" type="b" access="readwrite">
+      <tp:docstring>Enable external SSH access to dom0.</tp:docstring>
     </property>
     <property name="guest-only-networking" type="b" access="read">
       <tp:docstring>If true, networking features in dom0/networking VM are disabled.</tp:docstring>
     </property>
-    <property name="vm-creation-allowed" type="b" access="readwrite"> <tp:docstring>Allow creation of VMs on this host.</tp:docstring> </property>
-    <property name="vm-deletion-allowed" type="b" access="readwrite"> <tp:docstring>Allow deletion of VM on this host.</tp:docstring> </property>
-    <property name="ota-upgrades-allowed" type="b" access="readwrite"> <tp:docstring>Allow over the air upgrades on this host.</tp:docstring> </property>
-    <property name="connect-remote-desktop-allowed" type="b" access="readwrite"><tp:docstring>Allow using remote desktop (via icavm).</tp:docstring></property>
-
-    <property name="measure-fail-action" type="s" access="readwrite"> <tp:docstring>Action to perform when computing service VM checksum fails: sleep,hibernate,shutdown,reboot,nothing.</tp:docstring></property>
-    <property name="argo-firewall" type="b" access="readwrite">
-      <tp:docstring>If true, argo firewall is enabled, rejecting all incoming traffic by default.</tp:docstring>
+    <property name="iso-path" type="s" access="readwrite"/>
+    <property name="measure-fail-action" type="s" access="readwrite">
+      <tp:docstring>Action to perform when computing service VM checksum fails: sleep,hibernate,shutdown,reboot,nothing.</tp:docstring>
     </property>
-
+    <property name="ota-upgrades-allowed" type="b" access="readwrite">
+      <tp:docstring>Allow over the air upgrades on this host.</tp:docstring>
+    </property>
+    <property name="platform-crypto-key-dirs" type="s" access="readwrite">
+      <tp:docstring>Comma separated list of disk encryption keys directories.</tp:docstring>
+    </property>
+    <property name="pvm-autostart-delay" type="i" access="readwrite"/>
     <property name="secondary-gpu-pt" type="b" access="read">
       <tp:docstring>True if passthrough of secondary GPUs supported.</tp:docstring>
     </property>
-
-    <property name="configurable-save-changes-across-reboots" type="b" access="read">
-      <tp:docstring>True if user can opt to not save VHD changes across VM reboot.</tp:docstring>
+    <property name="svm-autostart-delay" type="i" access="readwrite"/>
+    <property name="use-networking-domain" type="b" access="read"/>
+    <property name="vm-creation-allowed" type="b" access="readwrite">
+      <tp:docstring>Allow creation of VMs on this host.</tp:docstring>
     </property>
-
-    <property name="enable-ssh" type="b" access="readwrite">
-      <tp:docstring>Enable external SSH access to dom0.</tp:docstring>
+    <property name="vm-deletion-allowed" type="b" access="readwrite">
+      <tp:docstring>Allow deletion of VM on this host.</tp:docstring>
     </property>
-
-    <property name="enable-argo-ssh" type="b" access="readwrite">
-      <tp:docstring>Enable internal SSH access to dom0.</tp:docstring>
-    </property>
-
-    <property name="enable-dom0-networking" type="b" access="readwrite">
-      <tp:docstring>Have dom0 connect to external network using DHCP.</tp:docstring>
-    </property>
-
-    <property name="dom0-mem-target-mib" type="i" access="readwrite"><tp:docstring>Dom0 balloon memory target, in mebibytes. If 0, don't balloon dom0.</tp:docstring></property>
-
-    <property name="autolock-cd-drives" type="b" access="readwrite">
-      <tp:docstring>Automatically lock/unlock cd drives to vms on media insert/eject events</tp:docstring>
-    </property>
-
+    <property name="xc-diag-timeout" type="i" access="readwrite"/>
   </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.xenmgr.config.ui">
     <tp:docstring>UI configuration information.</tp:docstring>
-    <property name="show-msg-on-vm-start" type="b" access="readwrite"/>
-    <property name="show-msg-on-vm-start-tools-warning" type="b" access="readwrite"/>
-    <property name="show-msg-on-no-disk" type="b" access="readwrite"/>
-    <property name="show-mboot-warning" type="b" access="readwrite"/>
-    <property name="show-tools-warning" type="b" access="readwrite"/>
-    <property name="wallpaper" type="s" access="readwrite"/>
-    <property name="pointer-trail-timeout" type="i" access="readwrite"/>
-    <property name="view-type" type="s" access="readwrite"/>
-    <property name="modify-settings" type="b" access="readwrite"/>
-    <property name="modify-services" type="b" access="readwrite"/>
-    <property name="modify-advanced-vm-settings" type="b" access="readwrite"/>
-
-    <property name="modify-usb-settings" type="b" access="readwrite">
-      <tp:docstring>If false, user will be unable to change vUSB device assignment.</tp:docstring>
-    </property>
-
-    <property name="switcher-enabled" type="b" access="readwrite">
-      <tp:docstring>True if seamless mouse switching is enabled.</tp:docstring>
-    </property>
-
-    <property name="switcher-self-switch-enabled" type="b" access="readwrite">
-      <tp:docstring>If false, switching to the actual current slot will do nothing.</tp:docstring>
-    </property>
-
-    <property name="switcher-keyboard-follows-mouse" type="b" access="readwrite">
-      <tp:docstring>If false, when mouse-switching, the keyboard stays in it's slot until a mouse click.</tp:docstring>
-    </property>
-
-    <property name="switcher-resistance" type="i" access="readwrite">
-      <tp:docstring>Determines how hard the edges are for mouse-switching.</tp:docstring>
-    </property>
-
-    <property name="switcher-status-report-enabled" type="b" access="readwrite">
-      <tp:docstring>If false, CTRL+ALT+R to generate a status report in the UI will be disabled.</tp:docstring>
-    </property>
-
-    <property name="idle-time-threshold" type="i" access="readwrite">
-      <tp:docstring>Determines the amount of time the host can be idle after which it goes to sleep.</tp:docstring>
-    </property>
-
-    <property name="language" type="s" access="readwrite">
-      <tp:docstring>Current language.</tp:docstring>
-    </property>
-
-    <property name="supported-languages" type="as" access="read">
-      <tp:docstring>List of supported languages.</tp:docstring>
-    </property>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Properties ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <property name="drm-graphics" type="b" access="readwrite">
       <tp:docstring>Enable DRM graphics plugin on older hardware (pre-haswell)</tp:docstring>
     </property>
-
+    <property name="idle-time-threshold" type="i" access="readwrite">
+      <tp:docstring>Determines the amount of time the host can be idle after which it goes to sleep.</tp:docstring>
+    </property>
+    <property name="language" type="s" access="readwrite">
+      <tp:docstring>Current language.</tp:docstring>
+    </property>
+    <property name="modify-advanced-vm-settings" type="b" access="readwrite"/>
+    <property name="modify-services" type="b" access="readwrite"/>
+    <property name="modify-settings" type="b" access="readwrite"/>
+    <property name="modify-usb-settings" type="b" access="readwrite">
+      <tp:docstring>If false, user will be unable to change vUSB device assignment.</tp:docstring>
+    </property>
+    <property name="pointer-trail-timeout" type="i" access="readwrite"/>
+    <property name="show-mboot-warning" type="b" access="readwrite"/>
+    <property name="show-msg-on-no-disk" type="b" access="readwrite"/>
+    <property name="show-msg-on-vm-start" type="b" access="readwrite"/>
+    <property name="show-msg-on-vm-start-tools-warning" type="b" access="readwrite"/>
+    <property name="show-tools-warning" type="b" access="readwrite"/>
+    <property name="supported-languages" type="as" access="read">
+      <tp:docstring>List of supported languages.</tp:docstring>
+    </property>
+    <property name="switcher-enabled" type="b" access="readwrite">
+      <tp:docstring>True if seamless mouse switching is enabled.</tp:docstring>
+    </property>
+    <property name="switcher-keyboard-follows-mouse" type="b" access="readwrite">
+      <tp:docstring>If false, when mouse-switching, the keyboard stays in it's slot until a mouse click.</tp:docstring>
+    </property>
+    <property name="switcher-resistance" type="i" access="readwrite">
+      <tp:docstring>Determines how hard the edges are for mouse-switching.</tp:docstring>
+    </property>
+    <property name="switcher-self-switch-enabled" type="b" access="readwrite">
+      <tp:docstring>If false, switching to the actual current slot will do nothing.</tp:docstring>
+    </property>
+    <property name="switcher-status-report-enabled" type="b" access="readwrite">
+      <tp:docstring>If false, CTRL+ALT+R to generate a status report in the UI will be disabled.</tp:docstring>
+    </property>
+    <property name="view-type" type="s" access="readwrite"/>
+    <property name="wallpaper" type="s" access="readwrite"/>
   </interface>
-
-  <interface name="com.citrix.xenclient.policy">
-    <tp:docstring>Implements the policy enforce/retrieve.</tp:docstring>
-
-    <method name="enforce">
-      <arg name="uuid" type="s" direction="in"/>
-      <arg name="value" type="s" direction="in"/>
-    </method>
-
-    <method name="retrieve">
-      <arg name="uuid" type="s" direction="in"/>
-      <arg name="result" type="s" direction="out"/>
-    </method>
-
-  </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.xenmgr.diag">
     <tp:docstring>Helpers for gathering diagnostic info from guests, and dom0.</tp:docstring>
-    <method name="save">
-      <tp:docstring>Get diagnostic information for VMs and save to the specified directory.</tp:docstring>
-      <arg name="mode" type="s" direction="in"/>
-      <arg name="dir" type="s" direction="out"/>
-    </method>
-    <method name="gather">
-      <tp:docstring>Put a file containing results of xc-diag to dom0.</tp:docstring>
-      <arg name="name" type="s" direction="in"/>
-      <arg name="data_" type="s" direction="in"/>
-    </method>
-    <signal name="gather_request">
-      <tp:docstring>Sent to notify guests to start preparing diagnostics info.</tp:docstring>
-      <arg name="mode" type="s"/>
-    </signal> 
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="create_status_report">
       <tp:docstring>Create a report using status-tool.</tp:docstring>
       <arg name="screenshots" type="b" direction="in"/>
@@ -343,14 +317,33 @@
       <arg name="ticket" type="s" direction="in"/>
       <arg name="file" type="s" direction="out"/>
     </method>
-
+    <method name="gather">
+      <tp:docstring>Put a file containing results of xc-diag to dom0.</tp:docstring>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="data_" type="s" direction="in"/>
+    </method>
+    <method name="save">
+      <tp:docstring>Get diagnostic information for VMs and save to the specified directory.</tp:docstring>
+      <arg name="mode" type="s" direction="in"/>
+      <arg name="dir" type="s" direction="out"/>
+    </method>
+    <method name="status_report_screen">
+      <tp:docstring>Show or hide the status report screen.</tp:docstring>
+      <arg name="show" type="b" direction="in"/>
+    </method>
+    <method name="taas_agree_terms">
+      <tp:docstring>TaaS Terms.</tp:docstring>
+      <arg name="username" type="s" direction="in"/>
+      <arg name="password" type="s" direction="in"/>
+      <arg name="version" type="s" direction="in"/>
+      <arg name="result" type="b" direction="out"/>
+    </method>
     <method name="taas_authenticate_credentials">
       <tp:docstring>Validate MyCitrix credentials.</tp:docstring>
       <arg name="username" type="s" direction="in"/>
       <arg name="password" type="s" direction="in"/>
       <arg name="result" type="as" direction="out"/>
     </method>
-
     <method name="taas_upload">
       <tp:docstring>Upload file to TaaS.</tp:docstring>
       <arg name="username" type="s" direction="in"/>
@@ -359,68 +352,74 @@
       <arg name="filename" type="s" direction="in"/>
       <arg name="result" type="b" direction="out"/>
     </method>
-
-    <method name="taas_agree_terms">
-      <tp:docstring>TaaS Terms.</tp:docstring>
-      <arg name="username" type="s" direction="in"/>
-      <arg name="password" type="s" direction="in"/>
-      <arg name="version" type="s" direction="in"/>
-      <arg name="result" type="b" direction="out"/>
-    </method>
-
-    <method name="status_report_screen">
-      <tp:docstring>Show or hide the status report screen.</tp:docstring>
-      <arg name="show" type="b" direction="in"/>
-    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <signal name="gather_request">
+      <tp:docstring>Sent to notify guests to start preparing diagnostics info.</tp:docstring>
+      <arg name="mode" type="s"/>
+    </signal>
   </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
+  <interface name="com.citrix.xenclient.xenmgr.guestreq">
+    <tp:docstring>Some well defined requests coming from guests.</tp:docstring>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="request_attention">
+      <tp:docstring>Guest requests user attention. Executing this method from any guest VM (User VM or Service VM) will cause a dialog box in both the UIVM and Windows guests to alert the user that the VM which sent it requires attention. This is useful for the case where a service VM needs credentials from the user or has an issue which requires user intervention to resolve. Note that the dialog box means a VM wants you to switch to the VM; but it does NOT mean that we recommend that you take any action, including but not limited to giving your attention to any VM that is requesting said attention. A malicious VM can repeatedly call this function and cause this dialog box to appear repeatedly; there is no time delay that limits how often any VM can request attention.</tp:docstring>
+    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <signal name="requested_attention">
+      <tp:docstring>Notify that VM has requested attention.</tp:docstring>
+      <arg name="uuid" type="s"/>
+      <arg name="obj_path" type="o"/>
+    </signal>
+  </interface>
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.xenmgr.testing">
     <tp:docstring>Helpers for automated testing.</tp:docstring>
-    <method name="script_queue">
-      <tp:docstring>Add a script to the fifo queue of test scripts to exercise in the UI.</tp:docstring>
-      <arg name="script" type="s" direction="in"/>
-    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="script_dequeue">
       <tp:docstring>Remove and return script.</tp:docstring>
       <arg name="script" type="s" direction="out"/>
     </method>
+    <method name="script_queue">
+      <tp:docstring>Add a script to the fifo queue of test scripts to exercise in the UI.</tp:docstring>
+      <arg name="script" type="s" direction="in"/>
+    </method>
   </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.xenmgr.unrestricted">
     <tp:docstring>Allows xenmgr operation ignoring policy checks so
     daemons in the control domain (dom0) can easily change
     settings.</tp:docstring>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="unrestricted_create_vm">
       <tp:docstring>Create a new VM.</tp:docstring>
       <arg name="path" type="o" direction="out"/>
     </method>
-
     <method name="unrestricted_create_vm_with_template_and_json">
       <tp:docstring>Create a new VM based on given template file and JSON blob. Template or json can be left empty.</tp:docstring>
       <arg name="template" type="s" direction="in"/>
       <arg name="json" type="s" direction="in"/>
       <arg name="path" type="o" direction="out"/>
     </method>
-
     <method name="unrestricted_delete_vm">
       <tp:docstring>Delete existing VM.</tp:docstring>
       <arg name="uuid" type="s" direction="in"/>
     </method>
-
-  </interface>
-
-  <interface name="com.citrix.xenclient.xenmgr.guestreq">
-    <tp:docstring>Some well defined requests coming from guests.</tp:docstring>
-    <method name="request_attention">
-      <tp:docstring>Guest requests user attention. Executing this method from any guest VM (User VM or Service VM) will cause a dialog box in both the UIVM and Windows guests to alert the user that the VM which sent it requires attention. This is useful for the case where a service VM needs credentials from the user or has an issue which requires user intervention to resolve. Note that the dialog box means a VM wants you to switch to the VM; but it does NOT mean that we recommend that you take any action, including but not limited to giving your attention to any VM that is requesting said attention. A malicious VM can repeatedly call this function and cause this dialog box to appear repeatedly; there is no time delay that limits how often any VM can request attention.</tp:docstring>
-    </method>
-
-    <signal name="requested_attention">
-      <tp:docstring>Notify that VM has requested attention.</tp:docstring>
-      <arg name="uuid" type="s"/>
-      <arg name="obj_path" type="o"/>
-    </signal>
-
   </interface>
 </node>

--- a/interfaces/xenmgr_host.xml
+++ b/interfaces/xenmgr_host.xml
@@ -1,255 +1,240 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/host" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
-
-  <interface name="com.citrix.xenclient.xenmgr.powersettings">
-    <tp:docstring>Let host object implement the power settings toggles.</tp:docstring>
-    <method name="get_ac_lid_close_action">
-      <tp:docstring>Returns the action to perform when the user closes the laptop lid when the device is attached to a power source.</tp:docstring>
-
-      <arg name="" type="s" direction="out">
-      </arg>
-    </method>
-    <method name="get_battery_lid_close_action">
-      <tp:docstring>Returns the action to perform when the user closes the laptop lid when the device is running on battery power.</tp:docstring>
-
-      <arg name="" type="s" direction="out">
-      </arg>
-    </method>
-    <method name="set_ac_lid_close_action">
-      <tp:docstring>Sets the action to perform when the user closes the laptop lid when the device is attached to a power source.</tp:docstring>
-
-      <arg name="action" type="s" direction="in">
-      </arg>
-    </method>
-    <method name="set_battery_lid_close_action">
-      <tp:docstring>Sets the action to perform when the user closes the laptop lid when the device is running on battery power.</tp:docstring>
-      <arg name="action" type="s" direction="in">
-	<tp:docstring></tp:docstring>
-      </arg>
-    </method>
-  </interface>
-
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/host">
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.xenmgr.host">
-    <signal name="state_changed">
-      <tp:docstring>Notify that the host state has changed (sleeping, hibernating etc).</tp:docstring>
-      <arg name="state" type="s"/>
-    </signal>
-
-    <signal name="storage_space_low">
-      <tp:docstring>Notify that the user is running out of storage space.</tp:docstring>
-      <arg name="percent_free" type="i">
-	<tp:docstring>The percentage of free disk space remaining.</tp:docstring>
-      </arg>
-    </signal>
-
-    <signal name="license_changed">
-      <tp:docstring>Notify that licensing evaluation has changed.</tp:docstring>
-    </signal>
-
-    <property name="state" type="s" access="read"/>
-    <property name="total-mem" type="i" access="read">
-      <tp:docstring>Total memory, in megabytes.</tp:docstring>
-    </property>
-    <property name="free-mem" type="i" access="read">
-      <tp:docstring>Free memory, in megabytes.</tp:docstring>
-    </property>
-    <property name="avail-mem" type="i" access="read">
-      <tp:docstring>Available memory, in megabytes. Can be bigger than free memory, since includes balloonable amount.</tp:docstring>
-    </property>
-
-    <property name="total-storage" type="i" access="read"/>
-    <property name="free-storage" type="i" access="read"/>
-
-    <property name="system-amt-pt" type="b" access="read"/>
-    <property name="cpu-count" type="i" access="read"/>
-    <property name="laptop" type="b" access="read"/>
-    <property name="model" type="s" access="read"/>
-    <property name="vendor" type="s" access="read"/>
-    <property name="serial" type="s" access="read"/>
-    <property name="bios-revision" type="s" access="read"/>
-    <property name="amt-capable" type="b" access="read"/>
-    <property name="eth0-mac" type="s" access="read"/>
-    <property name="eth0-model" type="s" access="read"/>
-    <property name="wireless-mac" type="s" access="read"/>
-    <property name="wireless-model" type="s" access="read"/>
-    <property name="physical-cpu-model" type="s" access="read"/>
-    <property name="physical-gpu-model" type="s" access="read"/>
-    <property name="safe-graphics" type="b" access="read"/>
-    <property name="measured-boot-enabled" type="b" access="read"/>
-    <property name="measured-boot-successful" type="b" access="read"/>
-    <property name="is-licensed" type="b" access="read"/>
-
-    <property name="build-info" type="a{ss}" access="read">
-      <tp:docstring>Build number, date and associated information.</tp:docstring>
-    </property>
-
-    <property name="ui-ready" type="b" access="readwrite">
-      <tp:docstring>UI please set this when you are ready. State will be stored in xenstore.</tp:docstring>
-    </property>
-
-    <property name="playback-pcm" type="s" access="readwrite">
-      <tp:docstring>PCM device used for audio playback</tp:docstring>
-    </property>
-
-    <property name="capture-pcm" type="s" access="readwrite">
-      <tp:docstring>PCM device used for audio capture</tp:docstring>
-    </property>
-
-    <method name="list_isos">
-      <tp:docstring>List the contents of the CD image (ISO) directory.</tp:docstring>
-      <arg name="" type="as" direction="out"/>
-    </method>
-
-    <method name="list_pci_devices">
-      <tp:docstring>List the PCI devices on the system. Returns a list of mappings, each including at least the device name, pciclass, vendor and ID.</tp:docstring>
-      <arg name="" type="aa{ss}" direction="out"/>
-    </method>
-
-    <method name="list_gpu_devices">
-      <tp:docstring>Like above, with some logic to filter GPU devices.</tp:docstring>
-      <arg name="" type="aa{ss}" direction="out"/>
-    </method>
-
-    <method name="list_disk_devices">
-      <tp:docstring>List the disk devices on system.</tp:docstring>
-      <arg name="" type="aa{ss}" direction="out"/>
-    </method>
-
-    <method name="list_playback_devices">
-      <tp:docstring>List audio playback devices on system</tp:docstring>
-      <arg name="" type="aa{ss}" direction="out"/>
-    </method>
-
-    <method name="list_capture_devices">
-      <tp:docstring>List audio capture devices on system</tp:docstring>
-      <arg name="" type="aa{ss}" direction="out"/>
-    </method>
-
-    <method name="list_sound_cards">
-      <tp:docstring>List sound cards on system</tp:docstring>
-      <arg name="" type="aa{ss}" direction="out"/>
-    </method>
-
-    <method name="list_sound_card_controls">
-      <tp:docstring>List controlable parameters of a sound card</tp:docstring>
-      <arg name="card" type="s" direction="in"/>
-      <arg name="" type="aa{ss}" direction="out"/>
-    </method>
-
-    <method name="get_sound_card_control">
-      <tp:docstring>Set sound card control parameter value</tp:docstring>
-      <arg name="card" type="s" direction="in"/>
-      <arg name="control" type="s" direction="in"/>
-      <arg name="value" type="s" direction="out"/>
-    </method>
-
-    <method name="set_sound_card_control">
-      <tp:docstring>Set sound card control parameter value</tp:docstring>
-      <arg name="card" type="s" direction="in"/>
-      <arg name="control" type="s" direction="in"/>
-      <arg name="value" type="s" direction="in"/>
-    </method>
-
-    <method name="list_cd_devices">
-      <tp:docstring>List cdrom devices on system</tp:docstring>
-      <arg name="" type="aa{ss}" direction="out"/>
-    </method>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="assign_cd_device">
       <tp:docstring>Assign CD device to given VM (or remove assignment if vm param empty)</tp:docstring>
       <arg name="devid" type="s" direction="in"/>
       <arg name="sticky" type="b" direction="in"/>
       <arg name="vm_uuid" type="s" direction="in"/>
     </method>
-
+    <method name="configure_gpu_placement">
+      <tp:docstring>Configures GPU placement for purposes of tracking VM switching when moving the mouse over the monitor edge. 0 = not set.</tp:docstring>
+      <arg name="id" type="s" direction="in">
+        <tp:docstring>GPU id</tp:docstring>
+      </arg>
+      <arg name="slot" type="i" direction="in">
+        <tp:docstring>Slot number, from left to right, in ascending order.</tp:docstring>
+      </arg>
+    </method>
+    <method name="eject_cd_device">
+      <tp:docstring>Physically eject media tray</tp:docstring>
+      <arg name="devid" type="s" direction="in"/>
+    </method>
     <method name="get_cd_device_assignment">
       <tp:docstring>Get CD device's assigned VM</tp:docstring>
       <arg name="devid" type="s" direction="in"/>
       <arg name="sticky" type="b" direction="out"/>
       <arg name="vm_uuid" type="s" direction="out"/>
     </method>
-
-    <method name="eject_cd_device">
-      <tp:docstring>Physically eject media tray</tp:docstring>
-      <arg name="devid" type="s" direction="in"/>
+    <method name="get_gpu_placement">
+      <tp:docstring>Get the GPU placement slot.</tp:docstring>
+      <arg name="id" type="s" direction="in">
+        <tp:docstring>GPU id</tp:docstring>
+      </arg>
+      <arg name="slot" type="i" direction="out">
+        <tp:docstring>GPU placement slot or 0 if not set.</tp:docstring>
+      </arg>
     </method>
-
+    <method name="get_seconds_from_epoch">
+      <tp:docstring>Get number of seconds from epoch.</tp:docstring>
+      <arg name="seconds" type="i" direction="out"/>
+    </method>
+    <method name="get_sound_card_control">
+      <tp:docstring>Set sound card control parameter value</tp:docstring>
+      <arg name="card" type="s" direction="in"/>
+      <arg name="control" type="s" direction="in"/>
+      <arg name="value" type="s" direction="out"/>
+    </method>
+    <method name="hibernate">
+      <tp:docstring>Send the host into s4 (hibernate).</tp:docstring>
+    </method>
+    <method name="is_service_running">
+      <tp:docstring>Tests if a named dbus service is currently running.</tp:docstring>
+      <arg name="service" type="s" direction="in">
+        <tp:docstring>The name of the service to check for.</tp:docstring>
+      </arg>
+      <arg name="running" type="b" direction="out">
+        <tp:docstring>Boolean value indicating whether the service is running.</tp:docstring>
+      </arg>
+    </method>
+    <method name="list_capture_devices">
+      <tp:docstring>List audio capture devices on system</tp:docstring>
+      <arg name="" type="aa{ss}" direction="out"/>
+    </method>
+    <method name="list_cd_devices">
+      <tp:docstring>List cdrom devices on system</tp:docstring>
+      <arg name="" type="aa{ss}" direction="out"/>
+    </method>
+    <method name="list_disk_devices">
+      <tp:docstring>List the disk devices on system.</tp:docstring>
+      <arg name="" type="aa{ss}" direction="out"/>
+    </method>
+    <method name="list_gpu_devices">
+      <tp:docstring>Like above, with some logic to filter GPU devices.</tp:docstring>
+      <arg name="" type="aa{ss}" direction="out"/>
+    </method>
+    <method name="list_isos">
+      <tp:docstring>List the contents of the CD image (ISO) directory.</tp:docstring>
+      <arg name="" type="as" direction="out"/>
+    </method>
+    <method name="list_pci_devices">
+      <tp:docstring>List the PCI devices on the system. Returns a list of mappings, each including at least the device name, pciclass, vendor and ID.</tp:docstring>
+      <arg name="" type="aa{ss}" direction="out"/>
+    </method>
+    <method name="list_playback_devices">
+      <tp:docstring>List audio playback devices on system</tp:docstring>
+      <arg name="" type="aa{ss}" direction="out"/>
+    </method>
+    <method name="list_sound_card_controls">
+      <tp:docstring>List controlable parameters of a sound card</tp:docstring>
+      <arg name="card" type="s" direction="in"/>
+      <arg name="" type="aa{ss}" direction="out"/>
+    </method>
+    <method name="list_sound_cards">
+      <tp:docstring>List sound cards on system</tp:docstring>
+      <arg name="" type="aa{ss}" direction="out"/>
+    </method>
     <method name="list_ui_plugins">
       <tp:docstring>List UI plugins on system.</tp:docstring>
       <arg name="subdir" type="s" direction="in"/>
       <arg name="list" type="as" direction="out"/>
     </method>
-
-    <method name="is_service_running">
-      <tp:docstring>Tests if a named dbus service is currently running.</tp:docstring>
-      <arg name="service" type="s" direction="in">
-	<tp:docstring>The name of the service to check for.</tp:docstring>
-      </arg>
-      <arg name="running" type="b" direction="out">
-	<tp:docstring>Boolean value indicating whether the service is running.</tp:docstring>
-      </arg>
-    </method>
-
-    <method name="configure_gpu_placement">
-      <tp:docstring>Configures GPU placement for purposes of tracking VM switching when moving the mouse over the monitor edge. 0 = not set.</tp:docstring>
-      <arg name="id" type="s" direction="in"><tp:docstring>GPU id</tp:docstring></arg>
-      <arg name="slot" type="i" direction="in">
-	<tp:docstring>Slot number, from left to right, in ascending order.</tp:docstring>
-      </arg>
-    </method>
-
-    <method name="get_gpu_placement">
-      <tp:docstring>Get the GPU placement slot.</tp:docstring>
-      <arg name="id" type="s" direction="in"><tp:docstring>GPU id</tp:docstring></arg>
-      <arg name="slot" type="i" direction="out"><tp:docstring>GPU placement slot or 0 if not set.</tp:docstring></arg>
-    </method>
-
-    <method name="get_seconds_from_epoch">
-      <tp:docstring>Get number of seconds from epoch.</tp:docstring>
-      <arg name="seconds" type="i" direction="out"/>
-    </method>
-
-    <method name="shutdown">
-      <tp:docstring>Shutdown the host device.</tp:docstring>
-    </method>
-
     <method name="reboot">
       <tp:docstring>Reboot the host device.</tp:docstring>
     </method>
-
-    <method name="sleep">
-      <tp:docstring>Send the host into s3 (sleep).</tp:docstring>
-    </method>
-
-    <method name="hibernate">
-      <tp:docstring>Send the host into s4 (hibernate).</tp:docstring>
-    </method>
-
     <method name="set_license">
       <arg name="expiry_date" type="s" direction="in">
-	<tp:docstring>Expiry date in the format yyyy-mm-dd HH:MM.</tp:docstring>
+        <tp:docstring>Expiry date in the format yyyy-mm-dd HH:MM.</tp:docstring>
       </arg>
       <arg name="device_uuid" type="s" direction="in"/>
       <arg name="hash" type="s" direction="in"/>
     </method>
+    <method name="set_sound_card_control">
+      <tp:docstring>Set sound card control parameter value</tp:docstring>
+      <arg name="card" type="s" direction="in"/>
+      <arg name="control" type="s" direction="in"/>
+      <arg name="value" type="s" direction="in"/>
+    </method>
+    <method name="shutdown">
+      <tp:docstring>Shutdown the host device.</tp:docstring>
+    </method>
+    <method name="sleep">
+      <tp:docstring>Send the host into s3 (sleep).</tp:docstring>
+    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <signal name="license_changed">
+      <tp:docstring>Notify that licensing evaluation has changed.</tp:docstring>
+    </signal>
+    <signal name="state_changed">
+      <tp:docstring>Notify that the host state has changed (sleeping, hibernating etc).</tp:docstring>
+      <arg name="state" type="s"/>
+    </signal>
+    <signal name="storage_space_low">
+      <tp:docstring>Notify that the user is running out of storage space.</tp:docstring>
+      <arg name="percent_free" type="i">
+        <tp:docstring>The percentage of free disk space remaining.</tp:docstring>
+      </arg>
+    </signal>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Properties ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <property name="amt-capable" type="b" access="read"/>
+    <property name="avail-mem" type="i" access="read">
+      <tp:docstring>Available memory, in megabytes. Can be bigger than free memory, since includes balloonable amount.</tp:docstring>
+    </property>
+    <property name="bios-revision" type="s" access="read"/>
+    <property name="build-info" type="a{ss}" access="read">
+      <tp:docstring>Build number, date and associated information.</tp:docstring>
+    </property>
+    <property name="capture-pcm" type="s" access="readwrite">
+      <tp:docstring>PCM device used for audio capture</tp:docstring>
+    </property>
+    <property name="cpu-count" type="i" access="read"/>
+    <property name="eth0-mac" type="s" access="read"/>
+    <property name="eth0-model" type="s" access="read"/>
+    <property name="free-mem" type="i" access="read">
+      <tp:docstring>Free memory, in megabytes.</tp:docstring>
+    </property>
+    <property name="free-storage" type="i" access="read"/>
+    <property name="is-licensed" type="b" access="read"/>
+    <property name="laptop" type="b" access="read"/>
+    <property name="measured-boot-enabled" type="b" access="read"/>
+    <property name="measured-boot-successful" type="b" access="read"/>
+    <property name="model" type="s" access="read"/>
+    <property name="physical-cpu-model" type="s" access="read"/>
+    <property name="physical-gpu-model" type="s" access="read"/>
+    <property name="playback-pcm" type="s" access="readwrite">
+      <tp:docstring>PCM device used for audio playback</tp:docstring>
+    </property>
+    <property name="safe-graphics" type="b" access="read"/>
+    <property name="serial" type="s" access="read"/>
+    <property name="state" type="s" access="read"/>
+    <property name="system-amt-pt" type="b" access="read"/>
+    <property name="total-mem" type="i" access="read">
+      <tp:docstring>Total memory, in megabytes.</tp:docstring>
+    </property>
+    <property name="total-storage" type="i" access="read"/>
+    <property name="ui-ready" type="b" access="readwrite">
+      <tp:docstring>UI please set this when you are ready. State will be stored in xenstore.</tp:docstring>
+    </property>
+    <property name="vendor" type="s" access="read"/>
+    <property name="wireless-mac" type="s" access="read"/>
+    <property name="wireless-model" type="s" access="read"/>
   </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.xenmgr.installer">
     <tp:docstring>Helpers methods for the OEM installer.</tp:docstring>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="get_eula">
       <tp:docstring>Contents of the EULA, or empty string.</tp:docstring>
       <arg name="eula" type="s" direction="out"/>
     </method>
-
     <method name="get_installstate">
       <tp:docstring>Get progress of the installation bits.</tp:docstring>
       <arg name="state" type="a{ss}" direction="out"/>
     </method>
-
     <method name="progress_installstate">
       <tp:docstring>Set progress of the installation bits.</tp:docstring>
       <arg name="action" type="s" direction="in"/>
     </method>
-
+  </interface>
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
+  <interface name="com.citrix.xenclient.xenmgr.powersettings">
+    <tp:docstring>Let host object implement the power settings toggles.</tp:docstring>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="get_ac_lid_close_action">
+      <tp:docstring>Returns the action to perform when the user closes the laptop lid when the device is attached to a power source.</tp:docstring>
+      <arg name="" type="s" direction="out"/>
+    </method>
+    <method name="get_battery_lid_close_action">
+      <tp:docstring>Returns the action to perform when the user closes the laptop lid when the device is running on battery power.</tp:docstring>
+      <arg name="" type="s" direction="out"/>
+    </method>
+    <method name="set_ac_lid_close_action">
+      <tp:docstring>Sets the action to perform when the user closes the laptop lid when the device is attached to a power source.</tp:docstring>
+      <arg name="action" type="s" direction="in"/>
+    </method>
+    <method name="set_battery_lid_close_action">
+      <tp:docstring>Sets the action to perform when the user closes the laptop lid when the device is running on battery power.</tp:docstring>
+      <arg name="action" type="s" direction="in">
+        <tp:docstring/>
+      </arg>
+    </method>
   </interface>
 </node>

--- a/interfaces/xenmgr_vm.xml
+++ b/interfaces/xenmgr_vm.xml
@@ -1,411 +1,207 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/vm/uuid" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
-
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0" name="/vm/uuid">
   <tp:enum name="VIRT_TYPE" type="s">
     <tp:docstring>Xen virtualization type.</tp:docstring>
     <tp:enumvalue suffix="PV" value="pv"/>
     <tp:enumvalue suffix="PVH" value="pvh"/>
     <tp:enumvalue suffix="HVM" value="hvm"/>
   </tp:enum>
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.xenmgr.vm">
     <tp:docstring>VM interface. Property access goes through policy checks.</tp:docstring>
-    <property name="state" type="s" access="read"/>
-    <property name="acpi-state" type="i" access="read"/>
-    <property name="domid" type="i" access="read"/>
-    <property name="type" type="s" access="readwrite"/>
-    <property name="name" type="s" access="readwrite"/>
-    <property name="description" type="s" access="readwrite"/>
-    <property name="uuid" type="s" access="read"/>
-    <property name="seamless-id" type="s" access="readwrite"><tp:docstring>Handle seamless uses to reference the VMs.</tp:docstring></property>
-    <property name="slot" type="i" access="readwrite"/>
-    <property name="pv-addons" type="b" access="readwrite"/>
-    <property name="pv-addons-version" type="s" access="readwrite"/>
-    <property name="start-on-boot" type="b" access="readwrite"/>
-    <property name="start-from-suspend-image" type="s" access="readwrite"><tp:docstring>Start VM from suspend image file, if it exists.</tp:docstring></property>
-    <property name="time-offset" type="i" access="readwrite"/>
-    <property name="crypto-user" type="s" access="readwrite"/>
-    <property name="auto-s3-wake" type="b" access="readwrite"/>
-    <property name="os" type="s" access="readwrite"/>
-
-    <property name="image-path" type="s" access="readwrite"/>
-    <property name="wired-network" type="s" access="readwrite"/>
-    <property name="wireless-network" type="s" access="readwrite"/>
-    <property name="gpu" type="s" access="readwrite"/>
-    <property name="cd" type="s" access="readwrite"/>
-    <property name="mac" type="s" access="read"/>
-    <property name="amt-pt" type="b" access="readwrite"/>
-    <property name="portica-enabled" type="i" access="read"/>
-    <property name="portica-installed" type="b" access="read"/>
-    <property name="seamless-traffic" type="b" access="readwrite"/>
-    <property name="autostart-pending" type="b" access="read"/>
-    <property name="hibernated" type="b" access="read"/>
-    <property name="memory-static-max" type="i" access="readwrite"/>
-    <property name="memory-target" type="i" access="read"/>
-    <property name="memory-min" type="i" access="readwrite"/>
-    <property name="memory" type="i" access="readwrite"/>
-    <property name="hidden-in-switcher" type="b" access="readwrite"/>
-    <property name="hidden-in-ui" type="b" access="readwrite"/>
-
-    <property name="notify" type="s" access="readwrite"/>
-    <property name="virt-type" type="s" access="readwrite"/><tp:docstring>One of pv, pvh, or hvm.</tp:docstring>
-    <property name="pae" type="b" access="readwrite"/>
-	<property name="acpi" type="b" access="readwrite"/>
-    <property name="apic" type="b" access="readwrite"/>
-    <property name="viridian" type="b" access="readwrite"/>
-    <property name="hap" type="b" access="readwrite"/>
-    <property name="nx" type="b" access="readwrite"/>
-    <property name="cpuid" type="s" access="readwrite"><tp:docstring>Used to set/unset certain bits in response to CPUID instruction.</tp:docstring></property>
-    <property name="xci-cpuid-signature" type="b" access="readwrite"><tp:docstring>Advertise to guest as XenClient flavour of Xen.</tp:docstring></property>
-    <property name="sound" type="s" access="readwrite"/>
-    <property name="display" type="s" access="readwrite"/>
-    <property name="boot" type="s" access="readwrite"/>
-    <property name="cmd-line" type="s" access="readwrite"/>
-    <property name="kernel-extract" type="s" access="readwrite">
-      <tp:docstring>[disk_number,partition_number:]/path/to/kernel
-	Location of kernel image within the VM's disk(s). Examples:
-	  /boot/vmlinuz (/boot/vmlinuz in unpartitioned disk 0)
-	  2:/boot/vmlinuz (/boot/vmlinuz in unpartitioned disk 2)
-	  0,1:/boot/vmlinuz (/boot/vmlinuz in 1st partitin of disk 0)
-      </tp:docstring>
-    </property>
-    <property name="kernel" type="s" access="readwrite"/>
-    <property name="initrd-extract" type="s" access="readwrite">
-      <tp:docstring>[disk_number,partition_number:]/path/to/initrd
-	Location of initrd image within the VM's disk(s). Examples:
-	  /boot/inird (/boot/inird in unpartitioned disk 0)
-	  2:/boot/inird (/boot/inird in unpartitioned disk 2)
-	  0,1:/boot/inird (/boot/inird in 1st partitin of disk 0)
-      </tp:docstring>
-    </property>
-    <property name="initrd" type="s" access="readwrite"/>
-    <property name="acpi-table" type="b" access="readwrite">
-      <tp:docstring>Enable OEM windows install by exposing the ACPI SLIC table.</tp:docstring>
-    </property>
-    <property name="vcpus" type="i" access="readwrite"/>
-    <property name="cores-per-socket" type="i" access="readwrite"/>
-    <property name="videoram" type="i" access="readwrite"/>
-    <property name="passthrough-mmio" type="s" access="readwrite"/>
-    <property name="passthrough-io" type="s" access="readwrite"/>
-    <property name="flask-label" type="s" access="readwrite"/>
-    <property name="init-flask-label" type="s" access="readwrite"/>
-    <property name="stubdom-flask-label" type="s" access="readwrite"/>
-    <property name="qemu-dm-path" type="s" access="readwrite"/>
-    <property name="qemu-dm-timeout" type="i" access="readwrite">
-      <tp:docstring>Timeout (in seconds) to wait for qemu response during qemu startup.</tp:docstring>
-    </property>
-    <property name="start-on-boot-priority" type="i" access="readwrite">
-      <tp:docstring>Control priority of start-on-boot VMs, higher priority means earlier start. Defaults to 0 for new VMs.</tp:docstring>
-    </property>
-
-    <property name="shutdown-priority" type="i" access="readwrite">
-      <tp:docstring>Controls the order of VM shutdown, higher priority means earlier shutdown. For new VMs defaults to 0, or -10 in case of PVM. VMs with the same priority are shutdown in parallel.</tp:docstring>
-    </property>
-
-    <property name="keep-alive" type="b" access="readwrite">
-      <tp:docstring>Automatically restart this VM if it shuts down or crashes.</tp:docstring>
-    </property>
-
-    <property name="provides-network-backend" type="b" access="readwrite">
-      <tp:docstring>Whether this domain is a networking backend and handles the physical NIC devices.</tp:docstring>
-    </property>
-
-    <property name="provides-default-network-backend" type="b" access="readwrite">
-      <tp:docstring>Whether this domain is the primary networking backend and handles the physical NIC devices.</tp:docstring>
-    </property>
-
-    <property name="provides-graphics-fallback" type="b" access="readwrite">
-      <tp:docstring>System will keep this VM on screen when no better candidate is present.</tp:docstring>
-    </property>
-
-    <property name="measured" type="b" access="read">
-      <tp:docstring>If the VM is measured, the hash of the disk image is checked before it is allowed to start.</tp:docstring>
-    </property>
-
-    <property name="extra-xenvm" type="s" access="readwrite">
-      <tp:docstring>Extra xenvm arguments, separated by semicolons.</tp:docstring>
-    </property>
-
-    <property name="extra-hvm" type="s" access="readwrite">
-      <tp:docstring>Extra ioemu arguments, separated by semicolons.</tp:docstring>
-    </property>
-
-    <property name="crypto-key-dirs" type="s" access="readwrite">
-      <tp:docstring>Comma-separated list of disk encryption keys directories.</tp:docstring>
-    </property>
-
-    <property name="dependencies" type="ao" access="read">
-      <tp:docstring>VMs that are required to be running before starting this one.</tp:docstring>
-    </property>
-
-    <property name="track-dependencies" type="b" access="readwrite">
-      <tp:docstring>If true, automatically start required VMs.</tp:docstring>
-    </property>
-
-    <property name="seamless-mouse-left" type="i" access="read">
-      <tp:docstring>Where to move mouse when it goes over the left edge of a surface.</tp:docstring>
-    </property>
-
-    <property name="seamless-mouse-right" type="i" access="read">
-      <tp:docstring>Where to move mouse when it goes over right edge of a surface.</tp:docstring>
-    </property>
-
-    <property name="control-platform-power-state" type="b" access="readwrite">
-      <tp:docstring>If set, the entire platform will go into S3/S4/S5 when this VM goes into S3/S4/S5.</tp:docstring>
-    </property>
-
-    <property name="oem-acpi-features" type="b" access="readwrite">
-      <tp:docstring>Enables access to additional OEM acpi features.</tp:docstring>
-    </property>
-
-    <property name="stubdom" type="b" access="readwrite"> <tp:docstring>Use stub domain to hide the device emulator.</tp:docstring> </property>
-    <property name="usb-enabled" type="b" access="readwrite"><tp:docstring>Enables PV USB support.</tp:docstring></property>
-    <property name="usb-auto-passthrough" type="b" access="readwrite"><tp:docstring>Enables automatic passthrough of new USB devices to VM currently in focus upon plugging in.</tp:docstring></property>
-    <property name="usb-control" type="b" access="readwrite"><tp:docstring>Enables the VM to communicate with the USB daemon.</tp:docstring></property>
-    <property name="usb-grab-devices" type="b" access="readwrite"><tp:docstring>Automatically assign all available USB devices upon this VM start.</tp:docstring></property>
-    <property name="greedy-pciback-bind" type="b" access="readwrite"><tp:docstring>Bind passthrough pci devices to pciback early, to prevent their use by other VMs.</tp:docstring></property>
-
-    <property name="policy-modify-vm-settings" type="b" access="readwrite"><tp:docstring>Allow modification of VM settings.</tp:docstring></property>
-    <property name="policy-cd-access" type="b" access="readwrite"><tp:docstring>Allow VM to read from CD.</tp:docstring></property>
-    <property name="policy-cd-recording" type="b" access="readwrite"><tp:docstring>Allow VM to burn CDs.</tp:docstring></property>
-    <property name="policy-audio-access" type="b" access="readwrite"><tp:docstring>Allow VM to playback audio.</tp:docstring></property>
-    <property name="policy-audio-recording" type="b" access="readwrite"><tp:docstring>Allow VM to record audio.</tp:docstring></property>
-    <property name="policy-wired-networking" type="b" access="readwrite"><tp:docstring>Allow VM to access wired network.</tp:docstring></property>
-    <property name="policy-wireless-networking" type="b" access="readwrite"><tp:docstring>Allow VM to access wireless network.</tp:docstring></property>
-    <property name="policy-print-screen" type="b" access="readwrite"><tp:docstring>Allow VM to use the PrintScreen key.</tp:docstring></property>
-
-    <property name="run-post-create" type="s" access="readwrite"><tp:docstring>Command to run post VM creation.</tp:docstring></property>
-    <property name="run-pre-delete" type="s" access="readwrite"><tp:docstring>Command to run pre VM deletion.</tp:docstring></property>
-    <property name="run-pre-boot" type="s" access="readwrite"><tp:docstring>Command to run synchronously pre VM boot.</tp:docstring></property>
-    <property name="run-insteadof-start" type="s" access="readwrite"><tp:docstring>Command to run instead of VM start</tp:docstring></property>
-
-    <property name="run-on-state-change" type="s" access="readwrite"><tp:docstring>Command to run on VM state change.</tp:docstring></property>
-    <property name="run-on-acpi-state-change" type="s" access="readwrite"><tp:docstring>Command to run on VM acpi state change.</tp:docstring></property>
-
-    <property name="domstore-read-access" type="b" access="readwrite"><tp:docstring>Configure domain read access to domstore.</tp:docstring></property>
-    <property name="domstore-write-access" type="b" access="readwrite"><tp:docstring>Configure domain write access to domstore.</tp:docstring></property>
-
-    <property name="show-switcher" type="b" access="readwrite"><tp:docstring>Hide/show switcher bar inside VM.</tp:docstring></property>
-    <property name="native-experience" type="b" access="readwrite"><tp:docstring>Toggle 'native experience' on/onff.</tp:docstring></property>
-    <property name="wireless-control" type="b" access="readwrite"><tp:docstring>Give VM control over wireless stack.</tp:docstring></property>
-
-    <property name="s3-mode" type="s" access="readwrite"><tp:docstring>Configure how the VM is put to sleep.</tp:docstring></property>
-    <property name="s4-mode" type="s" access="readwrite"><tp:docstring>Configure how the VM is hibernated.</tp:docstring></property>
-    <property name="vsnd" type="b" access="readwrite"><tp:docstring>Use PV audio device.</tp:docstring></property>
-    <property name="vkbd" type="b" access="readwrite"><tp:docstring>Use PV keyboard and mouse.</tp:docstring></property>
-    <property name="vfb" type="b" access="readwrite"><tp:docstring>Use PV framebuffer.</tp:docstring></property>
-    <property name="argo" type="b" access="readwrite"><tp:docstring>Use Argo.</tp:docstring></property>
-    <property name="private-space" type="i" access="read"><tp:docstring>Private space used (in MiB).</tp:docstring></property>
-    <property name="realm" type="s" access="readwrite"><tp:docstring>Realm ID.</tp:docstring></property>
-    <property name="sync-uuid" type="s" access="readwrite"><tp:docstring>VM UUID in synchroniser space.</tp:docstring></property>
-    <property name="icbinn-path" type="s" access="readwrite"><tp:docstring>Filesystem path exported to the VM via icbinn server.</tp:docstring></property>
-    <property name="ovf-transport-iso" type="b" access="readwrite"><tp:docstring>Transport of OVF configuration via iso enabled yes/no.</tp:docstring></property>
-    <property name="download-progress" type="i" access="readwrite"><tp:docstring>VM download progress.</tp:docstring></property>
-    <property name="ready" type="b" access="readwrite"><tp:docstring>Is VM ready for use?</tp:docstring></property>
-    <property name="restrict-display-depth" type="b" access="readwrite"><tp:docstring>Restrict available display depths. Currently required by emulated VGA in Windows 8.</tp:docstring></property>
-    <property name="restrict-display-res" type="b" access="readwrite"><tp:docstring>Restrict available display resolutions.</tp:docstring></property>
-    <property name="preserve-on-reboot" type="b" access="readwrite"><tp:docstring>After reboot, keep the vm in rebooted state instead of automatically restarting it</tp:docstring></property>
-    <property name="boot-sentinel" type="s" access="readwrite"><tp:docstring>Name of xenstore node to wait on before completing vm startup from toolstack PoV. Useful if VM exports services which need to be immediately usable by other vms</tp:docstring></property>
-    <property name="hpet" type="b" access="readwrite"><tp:docstring>HPET support</tp:docstring></property>
-    <property name="timer-mode" type="s" access="readwrite"><tp:docstring>Domain timer mode</tp:docstring></property>
-    <property name="nestedhvm" type="b" access="readwrite"><tp:docstring>Enable nested virtualization</tp:docstring></property>
-    <property name="serial" type="s" access="readwrite"><tp:docstring>Serial port specification</tp:docstring></property>
-    <property name="bios" type="s" access="readwrite"><tp:docstring>Bios specification</tp:docstring></property>
-    <property name="hdtype" type="s" access="readwrite"><tp:docstring>Hard disk type specification, 'ide' or 'ahci'</tp:docstring></property>
-
-    <method name="get_db_key">
-      <tp:docstring>Get the value of a VM db key.</tp:docstring>
-      <arg name="key" type="s" direction="in"/>
-      <arg name="value" type="s" direction="out"/>
+    <tp:docstring>One of pv, pvh, or hvm.</tp:docstring>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="add_argo_firewall_rule">
+      <arg name="rule" type="s" direction="in"/>
     </method>
-
-    <method name="set_db_key">
-      <tp:docstring>Set the value of a VM db key.</tp:docstring>
-      <arg name="key" type="s" direction="in"/>
-      <arg name="value" type="s" direction="in"/>
-    </method>
-
-    <method name="get_domstore_key">
-      <tp:docstring>Get the value of a VM domstore (domain accessible disk-based private storage) key.</tp:docstring>
-      <arg name="key" type="s" direction="in"/>
-      <arg name="value" type="s" direction="out"/>
-    </method>
-
-    <method name="set_domstore_key">
-      <tp:docstring>Set the value of a VM domstore (domain accessible disk-based private storage) key.</tp:docstring>
-      <arg name="key" type="s" direction="in"/>
-      <arg name="value" type="s" direction="in"/>
-    </method>
-
     <method name="add_disk">
       <tp:docstring>Add a new disk to VM.</tp:docstring>
       <arg name="path" type="o" direction="out"/>
     </method>
-
-    <method name="list_disks">
-      <tp:docstring>List the disk objects attached to this VM.</tp:docstring>
-      <arg name="" type="ao" direction="out"/>
-    </method>
-
-    <method name="add_nic">
-      <tp:docstring>Add a new NIC to the VM.</tp:docstring>
-      <arg name="path" type="o" direction="out"/>
-    </method>
-
-    <method name="list_nics">
-      <tp:docstring>List the NIC objects attached to the VM.</tp:docstring>
-      <arg name="" type="ao" direction="out"/>
-    </method>
-
-    <method name="delete">
-      <tp:docstring>Remove a VM.</tp:docstring>
-    </method>
-
-    <method name="switch">
-      <tp:docstring>Switch to a VM.</tp:docstring>
-    </method>
-
-    <method name="read_icon">
-      <tp:docstring>Read a byte array representing the VM icon image.</tp:docstring>
-      <arg name="bytes" type="ay" direction="out"/>
-    </method>
-
-    <method name="start">
-      <tp:docstring>Start the VM.</tp:docstring>
-    </method>
-
-    <method name="start_internal">
-      <tp:docstring>Start the VM, for internal use (bypass start hook)</tp:docstring>
-    </method>
-
-    <method name="reboot">
-      <tp:docstring>Reboot the VM.</tp:docstring>
-    </method>
-
-    <method name="shutdown">
-      <tp:docstring>Shutdown the VM.</tp:docstring>
-    </method>
-
-    <method name="destroy">
-      <tp:docstring>Force shutdown the VM.</tp:docstring>
-    </method>
-
-    <method name="sleep">
-      <tp:docstring>s3 the VM.</tp:docstring>
-    </method>
-
-    <method name="hibernate">
-      <tp:docstring>s4 the VM.</tp:docstring>
-    </method>
-
-    <method name="resume">
-      <tp:docstring>Wake the VM from s3.</tp:docstring>
-    </method>
-
-    <method name="pause">
-      <tp:docstring>Pause VM execution</tp:docstring>
-    </method>
-
-    <method name="unpause">
-      <tp:docstring>Resume VM execution from paused state</tp:docstring>
-    </method>
-
-    <method name="suspend_to_file">
-      <tp:docstring>Suspend the  VM to disk.</tp:docstring>
-      <arg name="file" type="s" direction="in"/>
-    </method>
-
-    <method name="resume_from_file">
-      <tp:docstring>Resume the VM from a suspended disk image.</tp:docstring>
-      <arg name="file" type="s" direction="in"/>
-    </method>
-
-    <method name="create_child_service_vm">
-      <tp:docstring>Create a subordinate Service VM.</tp:docstring>
-      <arg name="template" type="s" direction="in"/>
-      <arg name="path" type="o" direction="out"/>
-    </method>
-
-    <method name="list_argo_firewall_rules"> <arg name="rules" type="as" direction="out"/> </method>
-    <method name="add_argo_firewall_rule"> <arg name="rule" type="s" direction="in"/> </method>
-    <method name="delete_argo_firewall_rule"> <arg name="rule" type="s" direction="in"/> </method>
-
     <method name="add_net_firewall_rule">
       <arg name="id" type="i" direction="in"/>
       <arg name="direction" type="s" direction="in"/>
       <arg name="remoteip" type="s" direction="in"/>
       <arg name="extra" type="s" direction="in"/>
     </method>
-    <method name="list_net_firewall_rules">
-      <arg name="rules" type="aa{ss}" direction="out"/>
+    <method name="add_nic">
+      <tp:docstring>Add a new NIC to the VM.</tp:docstring>
+      <arg name="path" type="o" direction="out"/>
+    </method>
+    <method name="create_child_service_vm">
+      <tp:docstring>Create a subordinate Service VM.</tp:docstring>
+      <arg name="template" type="s" direction="in"/>
+      <arg name="path" type="o" direction="out"/>
+    </method>
+    <method name="delete">
+      <tp:docstring>Remove a VM.</tp:docstring>
+    </method>
+    <method name="delete_argo_firewall_rule">
+      <arg name="rule" type="s" direction="in"/>
     </method>
     <method name="delete_net_firewall_rule">
       <arg name="id" type="i" direction="in"/>
     </method>
-  </interface>
-
-  <interface name="com.citrix.xenclient.xenmgr.vm.unrestricted">
-    <tp:docstring>Allows unrestricted access to VM properties (without policy checks) so daemons in the control domain (dom0) can easily change settings.</tp:docstring>
-
-    <property name="state" type="s" access="read"/>
+    <method name="destroy">
+      <tp:docstring>Force shutdown the VM.</tp:docstring>
+    </method>
+    <method name="get_db_key">
+      <tp:docstring>Get the value of a VM db key.</tp:docstring>
+      <arg name="key" type="s" direction="in"/>
+      <arg name="value" type="s" direction="out"/>
+    </method>
+    <method name="get_domstore_key">
+      <tp:docstring>Get the value of a VM domstore (domain accessible disk-based private storage) key.</tp:docstring>
+      <arg name="key" type="s" direction="in"/>
+      <arg name="value" type="s" direction="out"/>
+    </method>
+    <method name="hibernate">
+      <tp:docstring>s4 the VM.</tp:docstring>
+    </method>
+    <method name="list_argo_firewall_rules">
+      <arg name="rules" type="as" direction="out"/>
+    </method>
+    <method name="list_disks">
+      <tp:docstring>List the disk objects attached to this VM.</tp:docstring>
+      <arg name="" type="ao" direction="out"/>
+    </method>
+    <method name="list_net_firewall_rules">
+      <arg name="rules" type="aa{ss}" direction="out"/>
+    </method>
+    <method name="list_nics">
+      <tp:docstring>List the NIC objects attached to the VM.</tp:docstring>
+      <arg name="" type="ao" direction="out"/>
+    </method>
+    <method name="pause">
+      <tp:docstring>Pause VM execution</tp:docstring>
+    </method>
+    <method name="read_icon">
+      <tp:docstring>Read a byte array representing the VM icon image.</tp:docstring>
+      <arg name="bytes" type="ay" direction="out"/>
+    </method>
+    <method name="reboot">
+      <tp:docstring>Reboot the VM.</tp:docstring>
+    </method>
+    <method name="resume">
+      <tp:docstring>Wake the VM from s3.</tp:docstring>
+    </method>
+    <method name="resume_from_file">
+      <tp:docstring>Resume the VM from a suspended disk image.</tp:docstring>
+      <arg name="file" type="s" direction="in"/>
+    </method>
+    <method name="set_db_key">
+      <tp:docstring>Set the value of a VM db key.</tp:docstring>
+      <arg name="key" type="s" direction="in"/>
+      <arg name="value" type="s" direction="in"/>
+    </method>
+    <method name="set_domstore_key">
+      <tp:docstring>Set the value of a VM domstore (domain accessible disk-based private storage) key.</tp:docstring>
+      <arg name="key" type="s" direction="in"/>
+      <arg name="value" type="s" direction="in"/>
+    </method>
+    <method name="shutdown">
+      <tp:docstring>Shutdown the VM.</tp:docstring>
+    </method>
+    <method name="sleep">
+      <tp:docstring>s3 the VM.</tp:docstring>
+    </method>
+    <method name="start">
+      <tp:docstring>Start the VM.</tp:docstring>
+    </method>
+    <method name="start_internal">
+      <tp:docstring>Start the VM, for internal use (bypass start hook)</tp:docstring>
+    </method>
+    <method name="suspend_to_file">
+      <tp:docstring>Suspend the  VM to disk.</tp:docstring>
+      <arg name="file" type="s" direction="in"/>
+    </method>
+    <method name="switch">
+      <tp:docstring>Switch to a VM.</tp:docstring>
+    </method>
+    <method name="unpause">
+      <tp:docstring>Resume VM execution from paused state</tp:docstring>
+    </method>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Properties ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <property name="acpi" type="b" access="readwrite"/>
     <property name="acpi-state" type="i" access="read"/>
-    <property name="domid" type="i" access="read"/>
-    <property name="type" type="s" access="readwrite"/>
-    <property name="name" type="s" access="readwrite"/>
-    <property name="description" type="s" access="readwrite"/>
-    <property name="uuid" type="s" access="read"/>
-    <property name="seamless-id" type="s" access="readwrite"><tp:docstring>Handle seamless uses to reference the VMs.</tp:docstring></property>
-    <property name="slot" type="i" access="readwrite"/>
-    <property name="pv-addons" type="b" access="readwrite"/>
-    <property name="pv-addons-version" type="s" access="readwrite"/>
-    <property name="start-on-boot" type="b" access="readwrite"/>
-    <property name="start-from-suspend-image" type="s" access="readwrite"><tp:docstring>Start the VM from the suspend image file, if it exists.</tp:docstring></property>
-    <property name="time-offset" type="i" access="readwrite"/>
-    <property name="crypto-user" type="s" access="readwrite"/>
-    <property name="auto-s3-wake" type="b" access="readwrite"/>
-    <property name="os" type="s" access="readwrite"/>
-
-    <property name="image-path" type="s" access="readwrite"/>
-    <property name="wired-network" type="s" access="readwrite"/>
-    <property name="wireless-network" type="s" access="readwrite"/>
-    <property name="gpu" type="s" access="readwrite"/>
-    <property name="cd" type="s" access="readwrite"/>
-    <property name="mac" type="s" access="read"/>
+    <property name="acpi-table" type="b" access="readwrite">
+      <tp:docstring>Enable OEM windows install by exposing the ACPI SLIC table.</tp:docstring>
+    </property>
     <property name="amt-pt" type="b" access="readwrite"/>
-    <property name="portica-enabled" type="i" access="read"/>
-    <property name="portica-installed" type="b" access="read"/>
-    <property name="seamless-traffic" type="b" access="readwrite"/>
+    <property name="apic" type="b" access="readwrite"/>
+    <property name="argo" type="b" access="readwrite">
+      <tp:docstring>Use Argo.</tp:docstring>
+    </property>
+    <property name="auto-s3-wake" type="b" access="readwrite"/>
     <property name="autostart-pending" type="b" access="read"/>
+    <property name="bios" type="s" access="readwrite">
+      <tp:docstring>Bios specification</tp:docstring>
+    </property>
+    <property name="boot" type="s" access="readwrite"/>
+    <property name="boot-sentinel" type="s" access="readwrite">
+      <tp:docstring>Name of xenstore node to wait on before completing vm startup from toolstack PoV. Useful if VM exports services which need to be immediately usable by other vms</tp:docstring>
+    </property>
+    <property name="cd" type="s" access="readwrite"/>
+    <property name="cmd-line" type="s" access="readwrite"/>
+    <property name="control-platform-power-state" type="b" access="readwrite">
+      <tp:docstring>If set, the entire platform will go into S3/S4/S5 when this VM goes into S3/S4/S5.</tp:docstring>
+    </property>
+    <property name="cores-per-socket" type="i" access="readwrite"/>
+    <property name="cpuid" type="s" access="readwrite">
+      <tp:docstring>Used to set/unset certain bits in response to CPUID instruction.</tp:docstring>
+    </property>
+    <property name="crypto-key-dirs" type="s" access="readwrite">
+      <tp:docstring>Comma-separated list of disk encryption keys directories.</tp:docstring>
+    </property>
+    <property name="crypto-user" type="s" access="readwrite"/>
+    <property name="dependencies" type="ao" access="read">
+      <tp:docstring>VMs that are required to be running before starting this one.</tp:docstring>
+    </property>
+    <property name="description" type="s" access="readwrite"/>
+    <property name="display" type="s" access="readwrite"/>
+    <property name="domid" type="i" access="read"/>
+    <property name="domstore-read-access" type="b" access="readwrite">
+      <tp:docstring>Configure domain read access to domstore.</tp:docstring>
+    </property>
+    <property name="domstore-write-access" type="b" access="readwrite">
+      <tp:docstring>Configure domain write access to domstore.</tp:docstring>
+    </property>
+    <property name="download-progress" type="i" access="readwrite">
+      <tp:docstring>VM download progress.</tp:docstring>
+    </property>
+    <property name="extra-hvm" type="s" access="readwrite">
+      <tp:docstring>Extra ioemu arguments, separated by semicolons.</tp:docstring>
+    </property>
+    <property name="extra-xenvm" type="s" access="readwrite">
+      <tp:docstring>Extra xenvm arguments, separated by semicolons.</tp:docstring>
+    </property>
+    <property name="flask-label" type="s" access="readwrite"/>
+    <property name="gpu" type="s" access="readwrite"/>
+    <property name="greedy-pciback-bind" type="b" access="readwrite">
+      <tp:docstring>Bind passthrough pci devices to pciback early, to prevent their use by other VMs.</tp:docstring>
+    </property>
+    <property name="hap" type="b" access="readwrite"/>
+    <property name="hdtype" type="s" access="readwrite">
+      <tp:docstring>Hard disk type specification, 'ide' or 'ahci'</tp:docstring>
+    </property>
     <property name="hibernated" type="b" access="read"/>
-    <property name="memory-static-max" type="i" access="readwrite"/>
-    <property name="memory-target" type="i" access="read"/>
-    <property name="memory-min" type="i" access="readwrite"/>
-    <property name="memory" type="i" access="readwrite"/>
     <property name="hidden-in-switcher" type="b" access="readwrite"/>
     <property name="hidden-in-ui" type="b" access="readwrite"/>
-
-    <property name="notify" type="s" access="readwrite"/>
-    <property name="virt-type" type="s" access="readwrite"/><tp:docstring>One of pv, pvh, or hvm.</tp:docstring>
-    <property name="pae" type="b" access="readwrite"/>
-	<property name="acpi" type="b" access="readwrite"/>
-    <property name="apic" type="b" access="readwrite"/>
-    <property name="viridian" type="b" access="readwrite"/>
-    <property name="cpuid" type="s" access="readwrite"><tp:docstring>Used to set/unset certain bits in response to CPUID instruction.</tp:docstring></property>
-    <property name="xci-cpuid-signature" type="b" access="readwrite"><tp:docstring>Advertise the guest as XenClient flavour of Xen.</tp:docstring></property>
-    <property name="hap" type="b" access="readwrite"/>
-    <property name="nx" type="b" access="readwrite"/>
-    <property name="sound" type="s" access="readwrite"/>
-    <property name="display" type="s" access="readwrite"/>
-    <property name="boot" type="s" access="readwrite"/>
-    <property name="cmd-line" type="s" access="readwrite"/>
-    <property name="kernel-extract" type="s" access="readwrite">
-      <tp:docstring>[disk_number,partition_number:]/path/to/kernel
-	Location of kernel image within the VM's disk(s). Examples:
-	  /boot/vmlinuz (/boot/vmlinuz in unpartitioned disk 0)
-	  2:/boot/vmlinuz (/boot/vmlinuz in unpartitioned disk 2)
-	  0,1:/boot/vmlinuz (/boot/vmlinuz in 1st partitin of disk 0)
-      </tp:docstring>
+    <property name="hpet" type="b" access="readwrite">
+      <tp:docstring>HPET support</tp:docstring>
     </property>
-    <property name="kernel" type="s" access="readwrite"/>
+    <property name="icbinn-path" type="s" access="readwrite">
+      <tp:docstring>Filesystem path exported to the VM via icbinn server.</tp:docstring>
+    </property>
+    <property name="image-path" type="s" access="readwrite"/>
+    <property name="init-flask-label" type="s" access="readwrite"/>
+    <property name="initrd" type="s" access="readwrite"/>
     <property name="initrd-extract" type="s" access="readwrite">
       <tp:docstring>[disk_number,partition_number:]/path/to/initrd
 	Location of initrd image within the VM's disk(s). Examples:
@@ -414,223 +210,583 @@
 	  0,1:/boot/inird (/boot/inird in 1st partitin of disk 0)
       </tp:docstring>
     </property>
-    <property name="initrd" type="s" access="readwrite"/>
-    <property name="acpi-table" type="b" access="readwrite">
-      <tp:docstring>Enable OEM windows installation by exposing the ACPI SLIC table.</tp:docstring>
-    </property>
-    <property name="vcpus" type="i" access="readwrite"/>
-    <property name="cores-per-socket" type="i" access="readwrite"/>
-    <property name="videoram" type="i" access="readwrite"/>
-    <property name="passthrough-mmio" type="s" access="readwrite"/>
-    <property name="passthrough-io" type="s" access="readwrite"/>
-    <property name="flask-label" type="s" access="readwrite"/>
-    <property name="init-flask-label" type="s" access="readwrite"/>
-    <property name="stubdom-flask-label" type="s" access="readwrite"/>
-    <property name="qemu-dm-path" type="s" access="readwrite"/>
-    <property name="qemu-dm-timeout" type="i" access="readwrite">
-      <tp:docstring>Timeout (in seconds) to wait for qemu response during its startup.</tp:docstring>
-    </property>
-
-    <property name="oem-acpi-features" type="b" access="readwrite">
-      <tp:docstring>Enables access to additional OEM acpi features.</tp:docstring>
-    </property>
-
-    <property name="start-on-boot-priority" type="i" access="readwrite">
-      <tp:docstring>Control priority of start-on-boot VMs, higher priority means earlier start. For new VMs this defaults to 0.</tp:docstring>
-    </property>
-
-    <property name="shutdown-priority" type="i" access="readwrite">
-      <tp:docstring>Controls order of vm shutdown, higher priority means earlier shutdown. For new VMs defaults to 0, or -10 in case of PVM. VMs with same priority are shutdown in parallel.</tp:docstring>
-    </property>
-
     <property name="keep-alive" type="b" access="readwrite">
       <tp:docstring>Automatically restart this VM if it shuts down or crashes.</tp:docstring>
     </property>
-
-    <property name="provides-network-backend" type="b" access="readwrite">
-      <tp:docstring>Whether this domain is a networking backend and handles the physical nic devices.</tp:docstring>
+    <property name="kernel" type="s" access="readwrite"/>
+    <property name="kernel-extract" type="s" access="readwrite">
+      <tp:docstring>[disk_number,partition_number:]/path/to/kernel
+	Location of kernel image within the VM's disk(s). Examples:
+	  /boot/vmlinuz (/boot/vmlinuz in unpartitioned disk 0)
+	  2:/boot/vmlinuz (/boot/vmlinuz in unpartitioned disk 2)
+	  0,1:/boot/vmlinuz (/boot/vmlinuz in 1st partitin of disk 0)
+      </tp:docstring>
     </property>
-
+    <property name="mac" type="s" access="read"/>
+    <property name="measured" type="b" access="read">
+      <tp:docstring>If the VM is measured, the hash of the disk image is checked before it is allowed to start.</tp:docstring>
+    </property>
+    <property name="memory" type="i" access="readwrite"/>
+    <property name="memory-min" type="i" access="readwrite"/>
+    <property name="memory-static-max" type="i" access="readwrite"/>
+    <property name="memory-target" type="i" access="read"/>
+    <property name="name" type="s" access="readwrite"/>
+    <property name="native-experience" type="b" access="readwrite">
+      <tp:docstring>Toggle 'native experience' on/onff.</tp:docstring>
+    </property>
+    <property name="nestedhvm" type="b" access="readwrite">
+      <tp:docstring>Enable nested virtualization</tp:docstring>
+    </property>
+    <property name="notify" type="s" access="readwrite"/>
+    <property name="nx" type="b" access="readwrite"/>
+    <property name="oem-acpi-features" type="b" access="readwrite">
+      <tp:docstring>Enables access to additional OEM acpi features.</tp:docstring>
+    </property>
+    <property name="os" type="s" access="readwrite"/>
+    <property name="ovf-transport-iso" type="b" access="readwrite">
+      <tp:docstring>Transport of OVF configuration via iso enabled yes/no.</tp:docstring>
+    </property>
+    <property name="pae" type="b" access="readwrite"/>
+    <property name="passthrough-io" type="s" access="readwrite"/>
+    <property name="passthrough-mmio" type="s" access="readwrite"/>
+    <property name="policy-audio-access" type="b" access="readwrite">
+      <tp:docstring>Allow VM to playback audio.</tp:docstring>
+    </property>
+    <property name="policy-audio-recording" type="b" access="readwrite">
+      <tp:docstring>Allow VM to record audio.</tp:docstring>
+    </property>
+    <property name="policy-cd-access" type="b" access="readwrite">
+      <tp:docstring>Allow VM to read from CD.</tp:docstring>
+    </property>
+    <property name="policy-cd-recording" type="b" access="readwrite">
+      <tp:docstring>Allow VM to burn CDs.</tp:docstring>
+    </property>
+    <property name="policy-modify-vm-settings" type="b" access="readwrite">
+      <tp:docstring>Allow modification of VM settings.</tp:docstring>
+    </property>
+    <property name="policy-print-screen" type="b" access="readwrite">
+      <tp:docstring>Allow VM to use the PrintScreen key.</tp:docstring>
+    </property>
+    <property name="policy-wired-networking" type="b" access="readwrite">
+      <tp:docstring>Allow VM to access wired network.</tp:docstring>
+    </property>
+    <property name="policy-wireless-networking" type="b" access="readwrite">
+      <tp:docstring>Allow VM to access wireless network.</tp:docstring>
+    </property>
+    <property name="portica-enabled" type="i" access="read"/>
+    <property name="portica-installed" type="b" access="read"/>
+    <property name="preserve-on-reboot" type="b" access="readwrite">
+      <tp:docstring>After reboot, keep the vm in rebooted state instead of automatically restarting it</tp:docstring>
+    </property>
+    <property name="private-space" type="i" access="read">
+      <tp:docstring>Private space used (in MiB).</tp:docstring>
+    </property>
     <property name="provides-default-network-backend" type="b" access="readwrite">
       <tp:docstring>Whether this domain is the primary networking backend and handles the physical NIC devices.</tp:docstring>
     </property>
-
     <property name="provides-graphics-fallback" type="b" access="readwrite">
       <tp:docstring>System will keep this VM on screen when no better candidate is present.</tp:docstring>
     </property>
-
-    <property name="measured" type="b" access="read">
-      <tp:docstring>if VM is measured, the hash of the disk image is checked before it is allowed to start.</tp:docstring>
+    <property name="provides-network-backend" type="b" access="readwrite">
+      <tp:docstring>Whether this domain is a networking backend and handles the physical NIC devices.</tp:docstring>
     </property>
-
-    <property name="extra-xenvm" type="s" access="readwrite">
-      <tp:docstring>Extra xenvm arguments separated by semicolon.</tp:docstring>
+    <property name="pv-addons" type="b" access="readwrite"/>
+    <property name="pv-addons-version" type="s" access="readwrite"/>
+    <property name="qemu-dm-path" type="s" access="readwrite"/>
+    <property name="qemu-dm-timeout" type="i" access="readwrite">
+      <tp:docstring>Timeout (in seconds) to wait for qemu response during qemu startup.</tp:docstring>
     </property>
-
-    <property name="extra-hvm" type="s" access="readwrite">
-      <tp:docstring>Extra ioemu arguments separated by semicolon.</tp:docstring>
+    <property name="ready" type="b" access="readwrite">
+      <tp:docstring>Is VM ready for use?</tp:docstring>
     </property>
-
-    <property name="crypto-key-dirs" type="s" access="readwrite">
-      <tp:docstring>Comma-separated list of disk encryption keys directories.</tp:docstring>
+    <property name="realm" type="s" access="readwrite">
+      <tp:docstring>Realm ID.</tp:docstring>
     </property>
-
-    <property name="dependencies" type="ao" access="read">
-      <tp:docstring>VMs that are required to be running before starting this one.</tp:docstring>
+    <property name="restrict-display-depth" type="b" access="readwrite">
+      <tp:docstring>Restrict available display depths. Currently required by emulated VGA in Windows 8.</tp:docstring>
     </property>
-
+    <property name="restrict-display-res" type="b" access="readwrite">
+      <tp:docstring>Restrict available display resolutions.</tp:docstring>
+    </property>
+    <property name="run-insteadof-start" type="s" access="readwrite">
+      <tp:docstring>Command to run instead of VM start</tp:docstring>
+    </property>
+    <property name="run-on-acpi-state-change" type="s" access="readwrite">
+      <tp:docstring>Command to run on VM acpi state change.</tp:docstring>
+    </property>
+    <property name="run-on-state-change" type="s" access="readwrite">
+      <tp:docstring>Command to run on VM state change.</tp:docstring>
+    </property>
+    <property name="run-post-create" type="s" access="readwrite">
+      <tp:docstring>Command to run post VM creation.</tp:docstring>
+    </property>
+    <property name="run-pre-boot" type="s" access="readwrite">
+      <tp:docstring>Command to run synchronously pre VM boot.</tp:docstring>
+    </property>
+    <property name="run-pre-delete" type="s" access="readwrite">
+      <tp:docstring>Command to run pre VM deletion.</tp:docstring>
+    </property>
+    <property name="s3-mode" type="s" access="readwrite">
+      <tp:docstring>Configure how the VM is put to sleep.</tp:docstring>
+    </property>
+    <property name="s4-mode" type="s" access="readwrite">
+      <tp:docstring>Configure how the VM is hibernated.</tp:docstring>
+    </property>
+    <property name="seamless-id" type="s" access="readwrite">
+      <tp:docstring>Handle seamless uses to reference the VMs.</tp:docstring>
+    </property>
+    <property name="seamless-mouse-left" type="i" access="read">
+      <tp:docstring>Where to move mouse when it goes over the left edge of a surface.</tp:docstring>
+    </property>
+    <property name="seamless-mouse-right" type="i" access="read">
+      <tp:docstring>Where to move mouse when it goes over right edge of a surface.</tp:docstring>
+    </property>
+    <property name="seamless-traffic" type="b" access="readwrite"/>
+    <property name="serial" type="s" access="readwrite">
+      <tp:docstring>Serial port specification</tp:docstring>
+    </property>
+    <property name="show-switcher" type="b" access="readwrite">
+      <tp:docstring>Hide/show switcher bar inside VM.</tp:docstring>
+    </property>
+    <property name="shutdown-priority" type="i" access="readwrite">
+      <tp:docstring>Controls the order of VM shutdown, higher priority means earlier shutdown. For new VMs defaults to 0, or -10 in case of PVM. VMs with the same priority are shutdown in parallel.</tp:docstring>
+    </property>
+    <property name="slot" type="i" access="readwrite"/>
+    <property name="sound" type="s" access="readwrite"/>
+    <property name="start-from-suspend-image" type="s" access="readwrite">
+      <tp:docstring>Start VM from suspend image file, if it exists.</tp:docstring>
+    </property>
+    <property name="start-on-boot" type="b" access="readwrite"/>
+    <property name="start-on-boot-priority" type="i" access="readwrite">
+      <tp:docstring>Control priority of start-on-boot VMs, higher priority means earlier start. Defaults to 0 for new VMs.</tp:docstring>
+    </property>
+    <property name="state" type="s" access="read"/>
+    <property name="stubdom" type="b" access="readwrite">
+      <tp:docstring>Use stub domain to hide the device emulator.</tp:docstring>
+    </property>
+    <property name="stubdom-flask-label" type="s" access="readwrite"/>
+    <property name="sync-uuid" type="s" access="readwrite">
+      <tp:docstring>VM UUID in synchroniser space.</tp:docstring>
+    </property>
+    <property name="time-offset" type="i" access="readwrite"/>
+    <property name="timer-mode" type="s" access="readwrite">
+      <tp:docstring>Domain timer mode</tp:docstring>
+    </property>
     <property name="track-dependencies" type="b" access="readwrite">
       <tp:docstring>If true, automatically start required VMs.</tp:docstring>
     </property>
-
-    <property name="seamless-mouse-left" type="i" access="read">
-      <tp:docstring>Where to move mouse when it goes over left edge.</tp:docstring>
+    <property name="type" type="s" access="readwrite"/>
+    <property name="usb-auto-passthrough" type="b" access="readwrite">
+      <tp:docstring>Enables automatic passthrough of new USB devices to VM currently in focus upon plugging in.</tp:docstring>
     </property>
-
-    <property name="seamless-mouse-right" type="i" access="read">
-      <tp:docstring>Where to move mouse when it goes over right edge.</tp:docstring>
+    <property name="usb-control" type="b" access="readwrite">
+      <tp:docstring>Enables the VM to communicate with the USB daemon.</tp:docstring>
     </property>
-
-    <property name="control-platform-power-state" type="b" access="readwrite">
-      <tp:docstring>If set, whole platform will go into S3/S4/S5 when this VM goes into S3/S4/S5.</tp:docstring>
+    <property name="usb-enabled" type="b" access="readwrite">
+      <tp:docstring>Enables PV USB support.</tp:docstring>
     </property>
-
-    <property name="stubdom" type="b" access="readwrite"> <tp:docstring>Use stub domain to hide the device emulator.</tp:docstring> </property>
-    <property name="stubdom-memory" type="i" access="readwrite"> <tp:docstring>Memory given to the stubdomain, in megabytes.</tp:docstring> </property>
-    <property name="stubdom-cmdline" type="s" access="readwrite"> <tp:docstring>Cmdline to be appended to the stubdomain's default cmdline.</tp:docstring> </property>
-    <property name="usb-enabled" type="b" access="readwrite"><tp:docstring>Enables PV USB support.</tp:docstring></property>
-    <property name="usb-auto-passthrough" type="b" access="readwrite"><tp:docstring>Enables automatic passthrough of new USB devices to VM currently in focus upon plugging in.</tp:docstring></property>
-    <property name="usb-control" type="b" access="readwrite"><tp:docstring>Enables VM to talk to USB daemon</tp:docstring></property>
-    <property name="usb-grab-devices" type="b" access="readwrite"><tp:docstring>Automatically assign all available USB devices upon this VM start.</tp:docstring></property>
-    <property name="greedy-pciback-bind" type="b" access="readwrite"><tp:docstring>Bind passthrough pci devices to pciback early, to prevent their use by other VMs.</tp:docstring></property>
-
-    <property name="policy-modify-vm-settings" type="b" access="readwrite"><tp:docstring>Allow modification of VM settings.</tp:docstring></property>
-    <property name="policy-cd-access" type="b" access="readwrite"><tp:docstring>Allow to read from CD.</tp:docstring></property>
-    <property name="policy-cd-recording" type="b" access="readwrite"><tp:docstring>Allow to record CD.</tp:docstring></property>
-    <property name="policy-audio-access" type="b" access="readwrite"><tp:docstring>Allow to playback audio.</tp:docstring></property>
-    <property name="policy-audio-recording" type="b" access="readwrite"><tp:docstring>Allow to record audio.</tp:docstring></property>
-    <property name="policy-wired-networking" type="b" access="readwrite"><tp:docstring>Allow to access wired network.</tp:docstring></property>
-    <property name="policy-wireless-networking" type="b" access="readwrite"><tp:docstring>Allow to access wireless network.</tp:docstring></property>
-    <property name="policy-print-screen" type="b" access="readwrite"><tp:docstring>Allow VM to use the PrintScreen key.</tp:docstring></property>
-
-    <property name="run-post-create" type="s" access="readwrite"><tp:docstring>Command to run post VM creation.</tp:docstring></property>
-    <property name="run-pre-delete" type="s" access="readwrite"><tp:docstring>Command to run pre VM deletion.</tp:docstring></property>
-    <property name="run-pre-boot" type="s" access="readwrite"><tp:docstring>Command to run synchronously pre VM boot.</tp:docstring></property>
-    <property name="run-insteadof-start" type="s" access="readwrite"><tp:docstring>Command to run instead of VM start</tp:docstring></property>
-
-    <property name="run-on-state-change" type="s" access="readwrite"><tp:docstring>Command to run on VM state change.</tp:docstring></property>
-    <property name="run-on-acpi-state-change" type="s" access="readwrite"><tp:docstring>Command to run on VM acpi state change.</tp:docstring></property>
-
-    <property name="domstore-read-access" type="b" access="readwrite"><tp:docstring>Configure domain read access to domstore.</tp:docstring></property>
-    <property name="domstore-write-access" type="b" access="readwrite"><tp:docstring>Configure domain write access to domstore.</tp:docstring></property>
-
-    <property name="show-switcher" type="b" access="readwrite"><tp:docstring>Hide/show switcher bar inside VM.</tp:docstring></property>
-    <property name="native-experience" type="b" access="readwrite"><tp:docstring>Toggle 'native experience' on/off.</tp:docstring></property>
-    <property name="wireless-control" type="b" access="readwrite"><tp:docstring>Give VM control over wireless stack.</tp:docstring></property>
-
-    <property name="s3-mode" type="s" access="readwrite"><tp:docstring>Configure how the VM is put to sleep.</tp:docstring></property>
-    <property name="s4-mode" type="s" access="readwrite"><tp:docstring>Configure how the VM is hibernated.</tp:docstring></property>
-    <property name="vsnd" type="b" access="readwrite"><tp:docstring>Use PV audio device.</tp:docstring></property>
-    <property name="vkbd" type="b" access="readwrite"><tp:docstring>Use PV keyboard and mouse.</tp:docstring></property>
-    <property name="vfb" type="b" access="readwrite"><tp:docstring>Use PV framebuffer.</tp:docstring></property>
-    <property name="argo" type="b" access="readwrite"><tp:docstring>Use Argo.</tp:docstring></property>
-    <property name="private-space" type="i" access="read"><tp:docstring>Private space used (in MiB).</tp:docstring></property>
-    <property name="realm" type="s" access="readwrite"><tp:docstring>Realm ID.</tp:docstring></property>
-    <property name="sync-uuid" type="s" access="readwrite"><tp:docstring>VM UUID in Synchroniser space.</tp:docstring></property>
-    <property name="icbinn-path" type="s" access="readwrite"><tp:docstring>Filesystem path exported to the VM via icbinn server.</tp:docstring></property>
-    <property name="ovf-transport-iso" type="b" access="readwrite"><tp:docstring>Transport of OVF configuration via iso enabled yes/no.</tp:docstring></property>
-    <property name="download-progress" type="i" access="readwrite"><tp:docstring>VM download progress.</tp:docstring></property>
-    <property name="ready" type="b" access="readwrite"><tp:docstring>Is VM ready for use?</tp:docstring></property>
-    <property name="restrict-display-depth" type="b" access="readwrite"><tp:docstring>Restrict available display depths. Currently required by emulated VGA in Windows 8.</tp:docstring></property>
-    <property name="restrict-display-res" type="b" access="readwrite"><tp:docstring>Restrict available display resolutions.</tp:docstring></property>
-    <property name="preserve-on-reboot" type="b" access="readwrite"><tp:docstring>After reboot, keep the vm in rebooted state instead of automatically restarting it</tp:docstring></property>
-    <property name="boot-sentinel" type="s" access="readwrite"><tp:docstring>Name of xenstore node to wait on before completing vm startup from toolstack PoV. Useful if VM exports services which need to be immediately usable by other vms</tp:docstring></property>
-    <property name="hpet" type="b" access="readwrite"><tp:docstring>HPET support</tp:docstring></property>
-    <property name="timer-mode" type="s" access="readwrite"><tp:docstring>Domain timer mode</tp:docstring></property>
-    <property name="nestedhvm" type="b" access="readwrite"><tp:docstring>Enable nested virtualization</tp:docstring></property>
-    <property name="serial" type="s" access="readwrite"><tp:docstring>Serial port specification</tp:docstring></property>
-    <property name="bios" type="s" access="readwrite"><tp:docstring>Bios specification</tp:docstring></property>
-    <property name="hdtype" type="s" access="readwrite"><tp:docstring>Hard disk type specification, 'ide' or 'ahci'</tp:docstring></property>
+    <property name="usb-grab-devices" type="b" access="readwrite">
+      <tp:docstring>Automatically assign all available USB devices upon this VM start.</tp:docstring>
+    </property>
+    <property name="uuid" type="s" access="read"/>
+    <property name="vcpus" type="i" access="readwrite"/>
+    <property name="vfb" type="b" access="readwrite">
+      <tp:docstring>Use PV framebuffer.</tp:docstring>
+    </property>
+    <property name="videoram" type="i" access="readwrite"/>
+    <property name="viridian" type="b" access="readwrite"/>
+    <property name="virt-type" type="s" access="readwrite"/>
+    <property name="vkbd" type="b" access="readwrite">
+      <tp:docstring>Use PV keyboard and mouse.</tp:docstring>
+    </property>
+    <property name="vsnd" type="b" access="readwrite">
+      <tp:docstring>Use PV audio device.</tp:docstring>
+    </property>
+    <property name="wired-network" type="s" access="readwrite"/>
+    <property name="wireless-control" type="b" access="readwrite">
+      <tp:docstring>Give VM control over wireless stack.</tp:docstring>
+    </property>
+    <property name="wireless-network" type="s" access="readwrite"/>
+    <property name="xci-cpuid-signature" type="b" access="readwrite">
+      <tp:docstring>Advertise to guest as XenClient flavour of Xen.</tp:docstring>
+    </property>
   </interface>
-
-  <interface name="com.citrix.xenclient.xenmgr.vm.product">
-    <tp:docstring>Configuration of products (services) in the VM.</tp:docstring>
-
-    <method name="get_ovf_env_xml">
-      <tp:docstring>Return the OVF environment xml.</tp:docstring>
-      <arg name="value" type="s" direction="out"/>
-    </method>
-
-    <method name="list_product_properties">
-      <tp:docstring>List all product properties for this VM.</tp:docstring>
-      <arg name="product_properties" type="aa{ss}" direction="out"/>
-    </method>
-
-    <method name="get_product_property">
-      <tp:docstring>Query product property value.</tp:docstring>
-      <arg name="property_id" type="s" direction="in"/>
-      <arg name="value" type="s" direction="out"/>
-    </method>
-
-    <method name="set_product_property">
-      <tp:docstring>Change product property value.</tp:docstring>
-      <arg name="property_id" type="s" direction="in"/>
-      <arg name="value" type="s" direction="in"/>
-    </method>
-  </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.xenmgr.vm.auth">
     <tp:docstring>Authentication Interface</tp:docstring>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="auth">
+      <tp:docstring>Attempt to authenticate to VM.</tp:docstring>
+    </method>
     <method name="auth_required">
       <tp:docstring>Check if authentication to VM is required.</tp:docstring>
       <arg name="required" type="b" direction="out"/>
     </method>
-
-    <method name="auth">
-      <tp:docstring>Attempt to authenticate to VM.</tp:docstring>
-    </method>
-
   </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
   <interface name="com.citrix.xenclient.xenmgr.vm.pci">
     <tp:docstring>Manipulate passthrough lists.</tp:docstring>
-
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
     <method name="add_pt_rule">
       <tp:docstring>Add PCI passthrough rule. Passing empty string in one of the arguments (class,vendor,device) turns off matching on that argument.</tp:docstring>
-
       <arg name="pciclass" type="s" direction="in"/>
       <arg name="vendor_id" type="s" direction="in"/>
       <arg name="device_id" type="s" direction="in"/>
     </method>
-
     <method name="add_pt_rule_bdf">
       <tp:docstring>Add PCI passthrough rule. Specify device using BDF syntax (e.g.: 0000:00:16.0).</tp:docstring>
       <arg name="bdf" type="s" direction="in"/>
     </method>
-
     <method name="delete_pt_rule">
       <tp:docstring>Remove passthrough rule(s).</tp:docstring>
       <arg name="pciclass" type="s" direction="in"/>
       <arg name="vendor_id" type="s" direction="in"/>
       <arg name="device_id" type="s" direction="in"/>
     </method>
-
     <method name="delete_pt_rule_bdf">
       <tp:docstring>Remove PCI passthrough rule using BDF syntax.</tp:docstring>
       <arg name="bdf" type="s" direction="in"/>
     </method>
-
-    <method name="list_pt_rules">
-      <tp:docstring>List current passthrough rules in effect.</tp:docstring>
-      <arg name="" type="aa{ss}" direction="out"/>
-    </method>
-
     <method name="list_pt_pci_devices">
       <tp:docstring>List PCI devices which match current passthrough rules.</tp:docstring>
       <arg name="" type="aa{ss}" direction="out"/>
     </method>
-
+    <method name="list_pt_rules">
+      <tp:docstring>List current passthrough rules in effect.</tp:docstring>
+      <arg name="" type="aa{ss}" direction="out"/>
+    </method>
   </interface>
-
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
+  <interface name="com.citrix.xenclient.xenmgr.vm.product">
+    <tp:docstring>Configuration of products (services) in the VM.</tp:docstring>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <method name="get_ovf_env_xml">
+      <tp:docstring>Return the OVF environment xml.</tp:docstring>
+      <arg name="value" type="s" direction="out"/>
+    </method>
+    <method name="get_product_property">
+      <tp:docstring>Query product property value.</tp:docstring>
+      <arg name="property_id" type="s" direction="in"/>
+      <arg name="value" type="s" direction="out"/>
+    </method>
+    <method name="list_product_properties">
+      <tp:docstring>List all product properties for this VM.</tp:docstring>
+      <arg name="product_properties" type="aa{ss}" direction="out"/>
+    </method>
+    <method name="set_product_property">
+      <tp:docstring>Change product property value.</tp:docstring>
+      <arg name="property_id" type="s" direction="in"/>
+      <arg name="value" type="s" direction="in"/>
+    </method>
+  </interface>
+  <!--~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~-->
+  <interface name="com.citrix.xenclient.xenmgr.vm.unrestricted">
+    <tp:docstring>Allows unrestricted access to VM properties (without policy checks) so daemons in the control domain (dom0) can easily change settings.</tp:docstring>
+    <tp:docstring>One of pv, pvh, or hvm.</tp:docstring>
+    <!--~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Properties ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~-->
+    <property name="acpi" type="b" access="readwrite"/>
+    <property name="acpi-state" type="i" access="read"/>
+    <property name="acpi-table" type="b" access="readwrite">
+      <tp:docstring>Enable OEM windows installation by exposing the ACPI SLIC table.</tp:docstring>
+    </property>
+    <property name="amt-pt" type="b" access="readwrite"/>
+    <property name="apic" type="b" access="readwrite"/>
+    <property name="argo" type="b" access="readwrite">
+      <tp:docstring>Use Argo.</tp:docstring>
+    </property>
+    <property name="auto-s3-wake" type="b" access="readwrite"/>
+    <property name="autostart-pending" type="b" access="read"/>
+    <property name="bios" type="s" access="readwrite">
+      <tp:docstring>Bios specification</tp:docstring>
+    </property>
+    <property name="boot" type="s" access="readwrite"/>
+    <property name="boot-sentinel" type="s" access="readwrite">
+      <tp:docstring>Name of xenstore node to wait on before completing vm startup from toolstack PoV. Useful if VM exports services which need to be immediately usable by other vms</tp:docstring>
+    </property>
+    <property name="cd" type="s" access="readwrite"/>
+    <property name="cmd-line" type="s" access="readwrite"/>
+    <property name="control-platform-power-state" type="b" access="readwrite">
+      <tp:docstring>If set, whole platform will go into S3/S4/S5 when this VM goes into S3/S4/S5.</tp:docstring>
+    </property>
+    <property name="cores-per-socket" type="i" access="readwrite"/>
+    <property name="cpuid" type="s" access="readwrite">
+      <tp:docstring>Used to set/unset certain bits in response to CPUID instruction.</tp:docstring>
+    </property>
+    <property name="crypto-key-dirs" type="s" access="readwrite">
+      <tp:docstring>Comma-separated list of disk encryption keys directories.</tp:docstring>
+    </property>
+    <property name="crypto-user" type="s" access="readwrite"/>
+    <property name="dependencies" type="ao" access="read">
+      <tp:docstring>VMs that are required to be running before starting this one.</tp:docstring>
+    </property>
+    <property name="description" type="s" access="readwrite"/>
+    <property name="display" type="s" access="readwrite"/>
+    <property name="domid" type="i" access="read"/>
+    <property name="domstore-read-access" type="b" access="readwrite">
+      <tp:docstring>Configure domain read access to domstore.</tp:docstring>
+    </property>
+    <property name="domstore-write-access" type="b" access="readwrite">
+      <tp:docstring>Configure domain write access to domstore.</tp:docstring>
+    </property>
+    <property name="download-progress" type="i" access="readwrite">
+      <tp:docstring>VM download progress.</tp:docstring>
+    </property>
+    <property name="extra-hvm" type="s" access="readwrite">
+      <tp:docstring>Extra ioemu arguments separated by semicolon.</tp:docstring>
+    </property>
+    <property name="extra-xenvm" type="s" access="readwrite">
+      <tp:docstring>Extra xenvm arguments separated by semicolon.</tp:docstring>
+    </property>
+    <property name="flask-label" type="s" access="readwrite"/>
+    <property name="gpu" type="s" access="readwrite"/>
+    <property name="greedy-pciback-bind" type="b" access="readwrite">
+      <tp:docstring>Bind passthrough pci devices to pciback early, to prevent their use by other VMs.</tp:docstring>
+    </property>
+    <property name="hap" type="b" access="readwrite"/>
+    <property name="hdtype" type="s" access="readwrite">
+      <tp:docstring>Hard disk type specification, 'ide' or 'ahci'</tp:docstring>
+    </property>
+    <property name="hibernated" type="b" access="read"/>
+    <property name="hidden-in-switcher" type="b" access="readwrite"/>
+    <property name="hidden-in-ui" type="b" access="readwrite"/>
+    <property name="hpet" type="b" access="readwrite">
+      <tp:docstring>HPET support</tp:docstring>
+    </property>
+    <property name="icbinn-path" type="s" access="readwrite">
+      <tp:docstring>Filesystem path exported to the VM via icbinn server.</tp:docstring>
+    </property>
+    <property name="image-path" type="s" access="readwrite"/>
+    <property name="init-flask-label" type="s" access="readwrite"/>
+    <property name="initrd" type="s" access="readwrite"/>
+    <property name="initrd-extract" type="s" access="readwrite">
+      <tp:docstring>[disk_number,partition_number:]/path/to/initrd
+	Location of initrd image within the VM's disk(s). Examples:
+	  /boot/inird (/boot/inird in unpartitioned disk 0)
+	  2:/boot/inird (/boot/inird in unpartitioned disk 2)
+	  0,1:/boot/inird (/boot/inird in 1st partitin of disk 0)
+      </tp:docstring>
+    </property>
+    <property name="keep-alive" type="b" access="readwrite">
+      <tp:docstring>Automatically restart this VM if it shuts down or crashes.</tp:docstring>
+    </property>
+    <property name="kernel" type="s" access="readwrite"/>
+    <property name="kernel-extract" type="s" access="readwrite">
+      <tp:docstring>[disk_number,partition_number:]/path/to/kernel
+	Location of kernel image within the VM's disk(s). Examples:
+	  /boot/vmlinuz (/boot/vmlinuz in unpartitioned disk 0)
+	  2:/boot/vmlinuz (/boot/vmlinuz in unpartitioned disk 2)
+	  0,1:/boot/vmlinuz (/boot/vmlinuz in 1st partitin of disk 0)
+      </tp:docstring>
+    </property>
+    <property name="mac" type="s" access="read"/>
+    <property name="measured" type="b" access="read">
+      <tp:docstring>if VM is measured, the hash of the disk image is checked before it is allowed to start.</tp:docstring>
+    </property>
+    <property name="memory" type="i" access="readwrite"/>
+    <property name="memory-min" type="i" access="readwrite"/>
+    <property name="memory-static-max" type="i" access="readwrite"/>
+    <property name="memory-target" type="i" access="read"/>
+    <property name="name" type="s" access="readwrite"/>
+    <property name="native-experience" type="b" access="readwrite">
+      <tp:docstring>Toggle 'native experience' on/off.</tp:docstring>
+    </property>
+    <property name="nestedhvm" type="b" access="readwrite">
+      <tp:docstring>Enable nested virtualization</tp:docstring>
+    </property>
+    <property name="notify" type="s" access="readwrite"/>
+    <property name="nx" type="b" access="readwrite"/>
+    <property name="oem-acpi-features" type="b" access="readwrite">
+      <tp:docstring>Enables access to additional OEM acpi features.</tp:docstring>
+    </property>
+    <property name="os" type="s" access="readwrite"/>
+    <property name="ovf-transport-iso" type="b" access="readwrite">
+      <tp:docstring>Transport of OVF configuration via iso enabled yes/no.</tp:docstring>
+    </property>
+    <property name="pae" type="b" access="readwrite"/>
+    <property name="passthrough-io" type="s" access="readwrite"/>
+    <property name="passthrough-mmio" type="s" access="readwrite"/>
+    <property name="policy-audio-access" type="b" access="readwrite">
+      <tp:docstring>Allow to playback audio.</tp:docstring>
+    </property>
+    <property name="policy-audio-recording" type="b" access="readwrite">
+      <tp:docstring>Allow to record audio.</tp:docstring>
+    </property>
+    <property name="policy-cd-access" type="b" access="readwrite">
+      <tp:docstring>Allow to read from CD.</tp:docstring>
+    </property>
+    <property name="policy-cd-recording" type="b" access="readwrite">
+      <tp:docstring>Allow to record CD.</tp:docstring>
+    </property>
+    <property name="policy-modify-vm-settings" type="b" access="readwrite">
+      <tp:docstring>Allow modification of VM settings.</tp:docstring>
+    </property>
+    <property name="policy-print-screen" type="b" access="readwrite">
+      <tp:docstring>Allow VM to use the PrintScreen key.</tp:docstring>
+    </property>
+    <property name="policy-wired-networking" type="b" access="readwrite">
+      <tp:docstring>Allow to access wired network.</tp:docstring>
+    </property>
+    <property name="policy-wireless-networking" type="b" access="readwrite">
+      <tp:docstring>Allow to access wireless network.</tp:docstring>
+    </property>
+    <property name="portica-enabled" type="i" access="read"/>
+    <property name="portica-installed" type="b" access="read"/>
+    <property name="preserve-on-reboot" type="b" access="readwrite">
+      <tp:docstring>After reboot, keep the vm in rebooted state instead of automatically restarting it</tp:docstring>
+    </property>
+    <property name="private-space" type="i" access="read">
+      <tp:docstring>Private space used (in MiB).</tp:docstring>
+    </property>
+    <property name="provides-default-network-backend" type="b" access="readwrite">
+      <tp:docstring>Whether this domain is the primary networking backend and handles the physical NIC devices.</tp:docstring>
+    </property>
+    <property name="provides-graphics-fallback" type="b" access="readwrite">
+      <tp:docstring>System will keep this VM on screen when no better candidate is present.</tp:docstring>
+    </property>
+    <property name="provides-network-backend" type="b" access="readwrite">
+      <tp:docstring>Whether this domain is a networking backend and handles the physical nic devices.</tp:docstring>
+    </property>
+    <property name="pv-addons" type="b" access="readwrite"/>
+    <property name="pv-addons-version" type="s" access="readwrite"/>
+    <property name="qemu-dm-path" type="s" access="readwrite"/>
+    <property name="qemu-dm-timeout" type="i" access="readwrite">
+      <tp:docstring>Timeout (in seconds) to wait for qemu response during its startup.</tp:docstring>
+    </property>
+    <property name="ready" type="b" access="readwrite">
+      <tp:docstring>Is VM ready for use?</tp:docstring>
+    </property>
+    <property name="realm" type="s" access="readwrite">
+      <tp:docstring>Realm ID.</tp:docstring>
+    </property>
+    <property name="restrict-display-depth" type="b" access="readwrite">
+      <tp:docstring>Restrict available display depths. Currently required by emulated VGA in Windows 8.</tp:docstring>
+    </property>
+    <property name="restrict-display-res" type="b" access="readwrite">
+      <tp:docstring>Restrict available display resolutions.</tp:docstring>
+    </property>
+    <property name="run-insteadof-start" type="s" access="readwrite">
+      <tp:docstring>Command to run instead of VM start</tp:docstring>
+    </property>
+    <property name="run-on-acpi-state-change" type="s" access="readwrite">
+      <tp:docstring>Command to run on VM acpi state change.</tp:docstring>
+    </property>
+    <property name="run-on-state-change" type="s" access="readwrite">
+      <tp:docstring>Command to run on VM state change.</tp:docstring>
+    </property>
+    <property name="run-post-create" type="s" access="readwrite">
+      <tp:docstring>Command to run post VM creation.</tp:docstring>
+    </property>
+    <property name="run-pre-boot" type="s" access="readwrite">
+      <tp:docstring>Command to run synchronously pre VM boot.</tp:docstring>
+    </property>
+    <property name="run-pre-delete" type="s" access="readwrite">
+      <tp:docstring>Command to run pre VM deletion.</tp:docstring>
+    </property>
+    <property name="s3-mode" type="s" access="readwrite">
+      <tp:docstring>Configure how the VM is put to sleep.</tp:docstring>
+    </property>
+    <property name="s4-mode" type="s" access="readwrite">
+      <tp:docstring>Configure how the VM is hibernated.</tp:docstring>
+    </property>
+    <property name="seamless-id" type="s" access="readwrite">
+      <tp:docstring>Handle seamless uses to reference the VMs.</tp:docstring>
+    </property>
+    <property name="seamless-mouse-left" type="i" access="read">
+      <tp:docstring>Where to move mouse when it goes over left edge.</tp:docstring>
+    </property>
+    <property name="seamless-mouse-right" type="i" access="read">
+      <tp:docstring>Where to move mouse when it goes over right edge.</tp:docstring>
+    </property>
+    <property name="seamless-traffic" type="b" access="readwrite"/>
+    <property name="serial" type="s" access="readwrite">
+      <tp:docstring>Serial port specification</tp:docstring>
+    </property>
+    <property name="show-switcher" type="b" access="readwrite">
+      <tp:docstring>Hide/show switcher bar inside VM.</tp:docstring>
+    </property>
+    <property name="shutdown-priority" type="i" access="readwrite">
+      <tp:docstring>Controls order of vm shutdown, higher priority means earlier shutdown. For new VMs defaults to 0, or -10 in case of PVM. VMs with same priority are shutdown in parallel.</tp:docstring>
+    </property>
+    <property name="slot" type="i" access="readwrite"/>
+    <property name="sound" type="s" access="readwrite"/>
+    <property name="start-from-suspend-image" type="s" access="readwrite">
+      <tp:docstring>Start the VM from the suspend image file, if it exists.</tp:docstring>
+    </property>
+    <property name="start-on-boot" type="b" access="readwrite"/>
+    <property name="start-on-boot-priority" type="i" access="readwrite">
+      <tp:docstring>Control priority of start-on-boot VMs, higher priority means earlier start. For new VMs this defaults to 0.</tp:docstring>
+    </property>
+    <property name="state" type="s" access="read"/>
+    <property name="stubdom" type="b" access="readwrite">
+      <tp:docstring>Use stub domain to hide the device emulator.</tp:docstring>
+    </property>
+    <property name="stubdom-cmdline" type="s" access="readwrite">
+      <tp:docstring>Cmdline to be appended to the stubdomain's default cmdline.</tp:docstring>
+    </property>
+    <property name="stubdom-flask-label" type="s" access="readwrite"/>
+    <property name="stubdom-memory" type="i" access="readwrite">
+      <tp:docstring>Memory given to the stubdomain, in megabytes.</tp:docstring>
+    </property>
+    <property name="sync-uuid" type="s" access="readwrite">
+      <tp:docstring>VM UUID in Synchroniser space.</tp:docstring>
+    </property>
+    <property name="time-offset" type="i" access="readwrite"/>
+    <property name="timer-mode" type="s" access="readwrite">
+      <tp:docstring>Domain timer mode</tp:docstring>
+    </property>
+    <property name="track-dependencies" type="b" access="readwrite">
+      <tp:docstring>If true, automatically start required VMs.</tp:docstring>
+    </property>
+    <property name="type" type="s" access="readwrite"/>
+    <property name="usb-auto-passthrough" type="b" access="readwrite">
+      <tp:docstring>Enables automatic passthrough of new USB devices to VM currently in focus upon plugging in.</tp:docstring>
+    </property>
+    <property name="usb-control" type="b" access="readwrite">
+      <tp:docstring>Enables VM to talk to USB daemon</tp:docstring>
+    </property>
+    <property name="usb-enabled" type="b" access="readwrite">
+      <tp:docstring>Enables PV USB support.</tp:docstring>
+    </property>
+    <property name="usb-grab-devices" type="b" access="readwrite">
+      <tp:docstring>Automatically assign all available USB devices upon this VM start.</tp:docstring>
+    </property>
+    <property name="uuid" type="s" access="read"/>
+    <property name="vcpus" type="i" access="readwrite"/>
+    <property name="vfb" type="b" access="readwrite">
+      <tp:docstring>Use PV framebuffer.</tp:docstring>
+    </property>
+    <property name="videoram" type="i" access="readwrite"/>
+    <property name="viridian" type="b" access="readwrite"/>
+    <property name="virt-type" type="s" access="readwrite"/>
+    <property name="vkbd" type="b" access="readwrite">
+      <tp:docstring>Use PV keyboard and mouse.</tp:docstring>
+    </property>
+    <property name="vsnd" type="b" access="readwrite">
+      <tp:docstring>Use PV audio device.</tp:docstring>
+    </property>
+    <property name="wired-network" type="s" access="readwrite"/>
+    <property name="wireless-control" type="b" access="readwrite">
+      <tp:docstring>Give VM control over wireless stack.</tp:docstring>
+    </property>
+    <property name="wireless-network" type="s" access="readwrite"/>
+    <property name="xci-cpuid-signature" type="b" access="readwrite">
+      <tp:docstring>Advertise the guest as XenClient flavour of Xen.</tp:docstring>
+    </property>
+  </interface>
 </node>

--- a/normalize-idl.xslt
+++ b/normalize-idl.xslt
@@ -1,0 +1,98 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+  <xsl:output method="xml" indent="yes" omit-xml-declaration="yes" doctype-public="-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" doctype-system="http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd"/>
+  <xsl:strip-space elements="*"/>
+  <xsl:preserve-space elements="tp:docstring p li ul ol"/>
+
+  <!-- start from the root node, sorting interfaces by name. -->
+  <xsl:template match="/node">
+    <xsl:copy>
+      <xsl:apply-templates select="@*">
+        <xsl:sort select="name()"/>
+      </xsl:apply-templates>
+      <xsl:apply-templates select="tp:enum">
+        <xsl:sort select="@name"/>
+      </xsl:apply-templates>
+      <xsl:apply-templates select="./interface">
+        <xsl:sort select="@name"/>
+      </xsl:apply-templates>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Preserve everything in comments, attributes, etc -->
+  <xsl:template match="@*|comment()|processing-instruction()">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+
+  <!-- Organize the contents of interface definitions. -->
+  <xsl:template match="/node/interface">
+    <xsl:comment>~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~  DBus Interface  ~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~</xsl:comment>
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+
+      <!-- Maintain enumeration definitions, but sort them by name -->
+      <xsl:apply-templates select="tp:enum">
+        <xsl:sort select="@name"/>
+      </xsl:apply-templates>
+
+      <!-- Copy any defined documentation -->
+      <xsl:apply-templates select="tp:docstring"/>
+
+      <!-- Copy all methods, if there are any, and sort them by name -->
+      <xsl:if test="method">
+        <xsl:comment>~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Methods    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~</xsl:comment>
+        <xsl:apply-templates select="method">
+          <xsl:sort select="@name"/>
+        </xsl:apply-templates>
+      </xsl:if>
+
+      <!-- Copy all signals, if there are any, and sort them by name -->
+      <xsl:if test="signal">
+        <xsl:comment>~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Signals    ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~</xsl:comment>
+        <xsl:apply-templates select="signal">
+          <xsl:sort select="@name"/>
+        </xsl:apply-templates>
+      </xsl:if>
+
+      <!-- Copy all properties, if there are any, and sort them by name -->
+      <xsl:if test="property">
+        <xsl:comment>~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~  DBus Properties ~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~</xsl:comment>
+        <xsl:apply-templates select="property">
+          <xsl:sort select="@name"/>
+        </xsl:apply-templates>
+      </xsl:if>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Maintain all subnodes of methods. Order of <arg> elements DOES matter, so never reorder them. -->
+  <xsl:template match="/node/interface/method">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+
+  <!-- Maintain all subnodes of signals. Order of <arg> elements DOES matter, so never reorder them. -->
+  <xsl:template match="/node/interface/signal">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+
+  <!-- Maintain all subnodes of properties. -->
+  <xsl:template match="/node/interface/property">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+
+  <!-- Maintain all documentation as-is. May change when auto-generating documentation based on that tool's requirements. -->
+  <xsl:template match="tp:docstring">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+
+  <!-- Maintain all enum documentation and values as-is. -->
+  <xsl:template match="tp:enum">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Use an XSLT to organize the IDL files without changing the semantics of any of the resulting stubs. This improves human-readability, especially if documentation auto-generators do not alphabetize or organize for themselves.