### PR TITLE
gitignore: create/update them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+oe-logs
+oe-workdir


### PR DESCRIPTION
externalsrc depends on a revision created with git add -A. Up to date gitignore would prevent unecessary rebuilds.