### PR TITLE
[host] Host shutdown idle function

### DIFF
--- a/interfaces/xenmgr_host.xml
+++ b/interfaces/xenmgr_host.xml
@@ -131,6 +131,9 @@
     <method name="shutdown">
       <tp:docstring>Shutdown the host device.</tp:docstring>
     </method>
+    <method name="shutdown_idle">
+      <tp:docstring>Shutdown the host device. VMs which fail to shutdown gracefully are forced off. Should be called by the power management subsystem after the system has reached the idle timeout.</tp:docstring>
+    </method>
     <method name="sleep">
       <tp:docstring>Send the host into s3 (sleep).</tp:docstring>
     </method>


### PR DESCRIPTION
  to isolate when this case is called. This allows for a configurable
  option to force the host to be shut down after the set amount of time
  has passed while it is attempting to do a regular shutdown.

Signed-off-by: Chris Rogers <crogers122@gmail.com>